### PR TITLE
Substituir 'formulario.voltar()' por 'cy.voltar()'

### DIFF
--- a/cypress/e2e/usuario.cy.js
+++ b/cypress/e2e/usuario.cy.js
@@ -1,7 +1,6 @@
 /// reference types="cypress" />
 import { fakerPT_BR } from '@faker-js/faker'
 import { getAuthToken } from '../support/authHelper'
-import formUsuarios from '../support/pageObjects/formUsuarios'
 let faker = require('faker-br')
 
 describe('Usuário', () => {
@@ -136,9 +135,8 @@ describe('Usuário', () => {
 		cy.validarDadosUsuario(dadosUpdate)
 
         // Alterar senha do usuário
-        const formulario = new formUsuarios()
         const senha = fakerPT_BR.internet.password()
-        formulario.voltar()
+        cy.voltar()
         cy.resetSenhaUsuario(`${dadosUpdate.nome} ${dadosUpdate.sobrenome}`, senha)
 
         // Inativação do usuário
@@ -211,9 +209,8 @@ describe('Usuário', () => {
         cy.validarDadosUsuario(dadosParaValidar)
 
         // Alterar senha do usuário
-        const formulario = new formUsuarios()
         const senha = fakerPT_BR.internet.password()
-        formulario.voltar()
+        cy.voltar()
         cy.resetSenhaUsuario(`${dados.nome} ${dados.sobrenome}`, senha)
 
         // Inativação do usuário
@@ -368,9 +365,8 @@ describe('Usuário', () => {
 		cy.validarDadosUsuario(dadosParaValidar)
         
         // Alterar senha do usuário
-        const formulario = new formUsuarios()
         const senha = fakerPT_BR.internet.password()
-        formulario.voltar()
+        cy.voltar()
         cy.resetSenhaUsuario(`${dadosUpdate.nome} ${dadosUpdate.sobrenome}`, senha)
 
         // Inativação do usuário
@@ -426,9 +422,8 @@ describe('Usuário', () => {
         cy.validarDadosUsuario(dadosParaValidar)
 
         // Alterar senha do usuário
-        const formulario = new formUsuarios()
         const senha = fakerPT_BR.internet.password()
-        formulario.voltar()
+        cy.voltar()
         cy.resetSenhaUsuario(`${dados.nome} ${dados.sobrenome}`, senha)
 
         // Inativação do usuário
@@ -528,9 +523,8 @@ describe('Usuário', () => {
 		cy.validarDadosUsuario(dadosParaValidar)
 
         // Alterar senha do usuário
-        const formulario = new formUsuarios()
         const senha = fakerPT_BR.internet.password()
-        formulario.voltar()
+        cy.voltar()
         cy.resetSenhaUsuario(`${dados.nome} ${dados.sobrenome}`, senha)
 
         // Inativação do usuário
@@ -580,9 +574,8 @@ describe('Usuário', () => {
         cy.validarDadosUsuario(dadosParaValidar)
 
         // Alterar senha do usuário
-        const formulario = new formUsuarios()
         const senha = fakerPT_BR.internet.password()
-        formulario.voltar()
+        cy.voltar()
         cy.resetSenhaUsuario(`${dados.nome} ${dados.sobrenome}`, senha)
 
         // Inativação do usuário
@@ -706,9 +699,8 @@ describe('Usuário', () => {
 		cy.validarDadosUsuario(dadosParaValidar)
 
         // Alterar senha do usuário
-        const formulario = new formUsuarios()
         const senha = fakerPT_BR.internet.password()
-        formulario.voltar()
+        cy.voltar()
         cy.resetSenhaUsuario(`${dados.nome} ${dados.sobrenome}`, senha)
 
         // Inativação do usuário


### PR DESCRIPTION
#### 🤖 FUNCIONALIDADE
Usuários

#### 🎯 AUTOMAÇÃO
Substituir 'formulario.voltar()' pelo comando personalizado 'cy.voltar()'

#### :heavy_check_mark: ATIVIDADE
{[Validações / análises / ajustes gerais / configurações / ambiente](https://app.artia.com/a/4874953/f/5152797/activities/27556601)}

#### :hammer_and_wrench: Tipo de mudança
 - [ ] Novos cenários (mudança que adiciona novos cenários automatizados)
 - [ ] Correção de quebras (alteração que corrige um problema)
 - [ ] Atualização de cenários (quando alterada a regra de negócio)
 - [X] Refatoração (Mudança no código que mantém o funcionamento como esperado)
 - [ ] Esta mudança requer uma atualização dos casos de testes no TestLink

#### :checkered_flag: CHECKLIST
- [X] Meu código segue as diretrizes de estilo deste projeto
- [X] Eu fiz uma autoavaliação do meu próprio código
- [X] Eu validei meus testes confirmando que minha implementação é eficaz ou que ela funciona como esperado
