### PR TITLE
Remover uncaught exception e ajustes na execução

### DIFF
--- a/cypress/e2e/biblioteca.cy.js
+++ b/cypress/e2e/biblioteca.cy.js
@@ -18,11 +18,11 @@ describe('Biblioteca', () => {
         })
     })
 
-    beforeEach(() => {
-        // Ativa o tratamento de exceção não capturada especificamente para este teste
-		Cypress.on('uncaught:exception', (err, runnable) => {
-            return false
-        })
+    beforeEach(() => {      
+        // Ignora mensagens de erro conhecidas
+        cy.ignorarCapturaErros([
+            "Unexpected identifier 'id'",
+        ], { ignoreScriptErrors: true})   
         
         //Define o tipo de conteúdo
         tipoConteudo = 'biblioteca'
@@ -41,9 +41,8 @@ describe('Biblioteca', () => {
     })
 
     afterEach(() => {
-		// Desativa o tratamento após o teste para evitar afetar outros testes
-		Cypress.removeAllListeners('uncaught:exception')
-	})
+        cy.ativarCapturaErros()
+    })
 
     it('1. CRUD biblioteca "Em companhia"', () => {
         // Massa de dados para criação da biblioteca

--- a/cypress/e2e/bibliotecaCriarAtividade.cy.js
+++ b/cypress/e2e/bibliotecaCriarAtividade.cy.js
@@ -136,11 +136,11 @@ describe('Criar atividade', () => {
     })
 
     beforeEach(() => {
-        // Ativa o tratamento de exceção não capturada especificamente para este teste
-		Cypress.on('uncaught:exception', (err, runnable) => {
-            return false
-        })
-
+        // Ignora mensagens de erro conhecidas
+        cy.ignorarCapturaErros([
+            "Unexpected identifier 'id'",
+        ], { ignoreScriptErrors: true, ignoreNetworkErrors: true})           
+        
         // Define o tipo de conteúdo
         tipoConteudo = 'biblioteca'
 
@@ -162,9 +162,8 @@ describe('Criar atividade', () => {
     })
 
     afterEach(() => {
-		// Desativa o tratamento após o teste para evitar afetar outros testes
-		Cypress.removeAllListeners('uncaught:exception')
-	})
+        cy.ativarCapturaErros()
+    })
 
     it('1. Criar uma atividade default', () => {
         // CREATE

--- a/cypress/e2e/catalogo.cy.js
+++ b/cypress/e2e/catalogo.cy.js
@@ -65,11 +65,11 @@ describe('catálogo', () => {
 	})
 
 	beforeEach(() => {
-		// Ativa o tratamento de exceção não capturada especificamente para este teste
-		Cypress.on('uncaught:exception', (err, runnable) => {
-		  	return false
-		})
-		
+		// Ignora mensagens de erro conhecidas
+		cy.ignorarCapturaErros([
+			"Unexpected identifier 'id'",
+		], { ignoreScriptErrors: true })
+				
 		// Define o tipo de conteúdo
 		tipoConteudo = 'catalogo'
 
@@ -87,13 +87,12 @@ describe('catálogo', () => {
 		// Exclui todos os catálogos antes de iniciar o teste
 		cy.excluirCatalogoViaApi()
 	})
-	
+
 	afterEach(() => {
-		// Desativa o tratamento após o teste para evitar afetar outros testes
-		Cypress.removeAllListeners('uncaught:exception')
+		cy.ativarCapturaErros()
 	})
 	
-	it.only('1. CRUD catalogo com dados default', () => {
+	it('1. CRUD catalogo com dados default', () => {
 		// Massa de dados para criação do catálogo
 		const conteudo = {
 			nome: fakerPT_BR.commerce.productName(),
@@ -649,7 +648,7 @@ describe('catálogo', () => {
 		cy.excluirConteudo(conteudo.nome, tipoConteudo)
 	})
 
-	it.only('7. CRUD catalogo em desenvolvimento, sem anexo, sem pagamento, com confirmação, com visualização para usuários', () => {
+	it('7. CRUD catalogo em desenvolvimento, sem anexo, sem pagamento, com confirmação, com visualização para usuários', () => {
 		// Massa de dados para criação do catálogo
 		categorias = [`Cat1-${fakerPT_BR.hacker.noun()}`, `Cat2-${fakerPT_BR.hacker.noun()}`]
 		const conteudo = {

--- a/cypress/e2e/catalogoCriarAtividade.cy.js
+++ b/cypress/e2e/catalogoCriarAtividade.cy.js
@@ -137,11 +137,11 @@ describe('Criar atividade', () => {
     })
 
     beforeEach(() => {
-        // Ativa o tratamento de exceção não capturada especificamente para este teste
-		Cypress.on('uncaught:exception', (err, runnable) => {
-            return false
-        })
-
+        // Ignora mensagens de erro conhecidas
+        cy.ignorarCapturaErros([
+            "Unexpected identifier 'id'"
+        ], { ignoreNetworkErrors: true })
+        
         // Define o tipo de conteúdo
         tipoConteudo = 'catalogo'
 
@@ -164,9 +164,8 @@ describe('Criar atividade', () => {
     })
 
     afterEach(() => {
-		// Desativa o tratamento após o teste para evitar afetar outros testes
-		Cypress.removeAllListeners('uncaught:exception')
-	})
+        cy.ativarCapturaErros()
+    })
 
     it('1. Criar uma atividade default', () => {
         // CREATE

--- a/cypress/e2e/catalogoCriarCurso.cy.js
+++ b/cypress/e2e/catalogoCriarCurso.cy.js
@@ -80,11 +80,11 @@ describe('criar curso via catálogo', () => {
 	})
 
 	beforeEach( () => {
-		// Ativa o tratamento de exceção não capturada especificamente para este teste
-		Cypress.on('uncaught:exception', (err, runnable) => {
-		  	return false
-		})
-
+		// Ignora mensagens de erro conhecidas
+		cy.ignorarCapturaErros([
+			"Unexpected identifier 'id'"
+		], { ignoreScriptErrors: true })
+		
 		// Define o tipo de conteúdo
 		tipoConteudo = 'criarCurso'
 
@@ -103,12 +103,11 @@ describe('criar curso via catálogo', () => {
 		cy.excluirCursoViaApi()
 		cy.excluirCatalogoViaApi()
 	})
-	
-	afterEach(() => {
-		// Desativa o tratamento após o teste para evitar afetar outros testes
-		Cypress.removeAllListeners('uncaught:exception')
-	})
 
+	afterEach(() => {
+		cy.ativarCapturaErros()
+	})
+	
 	it('1. CRUD deve criar um curso via catálogo com visualização para inscritos', () => {    
         // Massa de dados para criar um curso via catálogo
 		const catalogo = {

--- a/cypress/e2e/configUsuario.cy.js
+++ b/cypress/e2e/configUsuario.cy.js
@@ -13,11 +13,11 @@ describe('Configuração de Usuário', () => {
     })
 
     beforeEach(() => {
-        // Ativa o tratamento de exceção não capturada especificamente para este teste
-		Cypress.on('uncaught:exception', (err, runnable) => {
-            return false
-        })
-
+        // Ignora mensagens de erro conhecidas
+        cy.ignorarCapturaErros([
+            "Unexpected identifier 'id'"
+        ], { ignoreScriptErrors: true })
+        
         // Gerar dados aleatórios para o usuário
         nome = faker.person.firstName()
         sobrenome = faker.person.lastName()
@@ -30,9 +30,8 @@ describe('Configuração de Usuário', () => {
     })
 
     afterEach(() => {
-		// Desativa o tratamento após o teste para evitar afetar outros testes
-		Cypress.removeAllListeners('uncaught:exception')
-	})
+        cy.ativarCapturaErros()
+    })
 
     it('1. CRUD alterar os dados de usuário aluno e idioma para inglês', () => {
         // Massa de dados para criação do usuário
@@ -112,7 +111,6 @@ describe('Configuração de Usuário', () => {
         cy.alterarPerfil('administrador')
         cy.acessarPgUsuarios()
         cy.inativarUsuario(`${dadosUpdate.nome} ${dadosUpdate.sobrenome}`)
-        cy.pause()
     })
 
     it('2. CRUD alterar os dados de usuário instrutor e idioma para espanhol', () => {
@@ -202,7 +200,6 @@ describe('Configuração de Usuário', () => {
         cy.alterarPerfil('administrador')
         cy.acessarPgUsuarios()
         cy.inativarUsuario(`${dados.nome} ${dados.sobrenome}`)
-        cy.pause()
     })
 
     it('3. CRUD alterar os dados de usuário gestor e idioma para inglês e depois português', () => {
@@ -300,7 +297,6 @@ describe('Configuração de Usuário', () => {
         cy.alterarPerfil('administrador')
         cy.acessarPgUsuarios()
         cy.inativarUsuario(`${dados.nome} ${dados.sobrenome}`)
-        cy.pause()
     })
 
     it('4. CRUD alterar os dados de usuário administrador sem alterar idioma', () => {
@@ -385,6 +381,5 @@ describe('Configuração de Usuário', () => {
         cy.alterarPerfil('administrador')
         cy.acessarPgUsuarios()
         cy.inativarUsuario(`${dados.nome} ${dados.sobrenome}`)
-        cy.pause()
     })
 })

--- a/cypress/e2e/curso.cy.js
+++ b/cypress/e2e/curso.cy.js
@@ -63,11 +63,11 @@ describe('curso', () => {
 	})
 
 	beforeEach( () => {
-		// Ativa o tratamento de exceção não capturada especificamente para este teste
-		Cypress.on('uncaught:exception', (err, runnable) => {
-		  	return false
-		})
-
+		// Ignora mensagens de erro conhecidas
+		cy.ignorarCapturaErros([
+			"Unexpected identifier 'id'"
+		], { ignoreScriptErrors: true })
+		
 		// Define o tipo de conteúdo
 		tipoConteudo = 'curso'
 
@@ -85,13 +85,12 @@ describe('curso', () => {
 		// Exclui todos os cursos antes de iniciar o teste
 		cy.excluirCursoViaApi()
 	})
-	
+
 	afterEach(() => {
-		// Desativa o tratamento após o teste para evitar afetar outros testes
-		Cypress.removeAllListeners('uncaught:exception')
+		cy.ativarCapturaErros()
 	})
 	
-	it.only('1. CRUD curso com dados default', () =>{
+	it('1. CRUD curso com dados default', () =>{
 		// Massa de dados para criação do curso
         const conteudo = {
 			nome: nome,
@@ -661,7 +660,7 @@ describe('curso', () => {
 		cy.excluirConteudo(conteudo.nome, tipoConteudo)
 	})
 
-	it.only('7. CRUD curso em desenvolvimento, sem anexo, sem pagamento, com confirmação, com visualização para usuários', () => {
+	it('7. CRUD curso em desenvolvimento, sem anexo, sem pagamento, com confirmação, com visualização para usuários', () => {
 		// Massa de dados para criação do curso
 		categorias = [`Cat1-${fakerPT_BR.hacker.noun()}`, `Cat2-${fakerPT_BR.hacker.noun()}`]
 		const conteudo = {

--- a/cypress/e2e/cursoCriarAtividade.cy.js
+++ b/cypress/e2e/cursoCriarAtividade.cy.js
@@ -137,11 +137,11 @@ describe('Criar atividade', () => {
     })
 
     beforeEach(() => {
-        // Ativa o tratamento de exceção não capturada especificamente para este teste
-		Cypress.on('uncaught:exception', (err, runnable) => {
-            return false
-        })
-
+        // Ignora mensagens de erro conhecidas
+        cy.ignorarCapturaErros([
+            "Unexpected identifier 'id'"
+        ], { ignoreNetworkErrors: true })
+        
         // Define o tipo de conteúdo
         tipoConteudo = 'curso'
 
@@ -164,9 +164,8 @@ describe('Criar atividade', () => {
     })
 
     afterEach(() => {
-		// Desativa o tratamento após o teste para evitar afetar outros testes
-		Cypress.removeAllListeners('uncaught:exception')
-	})
+        cy.ativarCapturaErros()
+    })
 
     it('1. Criar uma atividade default', () => {
         // CREATE
@@ -340,7 +339,7 @@ describe('Criar atividade', () => {
         cy.excluirAtividade(dadosUpdate.titulo)
     })
 
-    it.only('4. CRUD atividade do tipo "Vídeo"', () => {
+    it('4. CRUD atividade do tipo "Vídeo"', () => {
         // Massa de dados para criação de atividade
         const dados = {
             titulo: nomeAtividade,

--- a/cypress/e2e/cursoInscricao.cy.js
+++ b/cypress/e2e/cursoInscricao.cy.js
@@ -46,11 +46,11 @@ describe('Participante', () => {
 	})
     
     beforeEach(() => {
-        // Ativa o tratamento de exceção não capturada especificamente para este teste
-		Cypress.on('uncaught:exception', (err, runnable) => {
-            return false
-        })
-
+        // Ignora mensagens de erro conhecidas
+        cy.ignorarCapturaErros([
+            "Unexpected identifier 'id'"
+        ], { ignoreScriptErrors: true })
+        
         // Obtém token autenticação, lista e exclui os usuários e cursos
         getAuthToken()
         cy.excluirUsuarioViaApi()
@@ -69,9 +69,8 @@ describe('Participante', () => {
     })
 
     afterEach(() => {
-		// Desativa o tratamento após o teste para evitar afetar outros testes
-		Cypress.removeAllListeners('uncaught:exception')
-	})
+        cy.ativarCapturaErros()
+    })
 
     it('1. CRUD participante default', () => {
         // Massa de dados
@@ -134,7 +133,7 @@ describe('Participante', () => {
         }
 
         cy.preencherDadosParticipante(dadosUpdate, { limpar: true })
-        cy.salvarEdicaoParticipante(`${dadosUpdate.nome} ${dadosUpdate.sobrenome}`)
+        cy.salvarEdicaoParticipante(`${dadosUpdate.nome} ${dadosUpdate.sobrenome}`, 'Confirmados')
 
 		// READ-UPDATE
 		cy.log('## READ-UPDATE ##')
@@ -237,7 +236,7 @@ describe('Participante', () => {
         }
 
         cy.preencherDadosParticipante(dadosUpdate, { limpar: true })
-        cy.salvarEdicaoParticipante(`${dadosUpdate.nome} ${dadosUpdate.sobrenome}`)
+        cy.salvarEdicaoParticipante(`${dadosUpdate.nome} ${dadosUpdate.sobrenome}`, 'Confirmados')
 
 		// READ-UPDATE
 		cy.log('## READ-UPDATE ##')
@@ -316,7 +315,7 @@ describe('Participante', () => {
         }
 
         cy.preencherDadosParticipante(dadosUpdate, { limpar: true })
-        cy.salvarEdicaoParticipante(`${dados.nome} ${dados.sobrenome}`)
+        cy.salvarEdicaoParticipante(`${dados.nome} ${dados.sobrenome}`, 'Confirmados')
 
 		// READ-UPDATE
 		cy.log('## READ-UPDATE ##')
@@ -382,7 +381,7 @@ describe('Participante', () => {
         }
 
         cy.preencherDadosParticipante(dadosUpdate, { limpar: true })
-        cy.salvarEdicaoParticipante(`${dadosUpdate.nome} ${dadosUpdate.sobrenome}`)
+        cy.salvarEdicaoParticipante(`${dadosUpdate.nome} ${dadosUpdate.sobrenome}`, 'Confirmados')
 
 		// READ-UPDATE
 		cy.log('## READ-UPDATE ##')
@@ -442,7 +441,7 @@ describe('Participante', () => {
         }
 
         cy.preencherDadosParticipante(dadosUpdate, { limpar: true })
-        cy.salvarEdicaoParticipante(`${dados.nome} ${dados.sobrenome}`)
+        cy.salvarEdicaoParticipante(`${dados.nome} ${dados.sobrenome}`, 'Confirmados')
 
 		// READ-UPDATE
 		cy.log('## READ-UPDATE ##')
@@ -514,7 +513,7 @@ describe('Participante', () => {
         }
 
         cy.preencherDadosParticipante(dadosUpdate, { limpar: true })
-        cy.salvarEdicaoParticipante(`${dados.nome} ${dados.sobrenome}`)
+        cy.salvarEdicaoParticipante(`${dados.nome} ${dados.sobrenome}`, 'Confirmados')
 
 		// READ-UPDATE
 		cy.log('## READ-UPDATE ##')
@@ -590,7 +589,7 @@ describe('Participante', () => {
         }
 
         cy.preencherDadosParticipante(dadosUpdate, { limpar: true })
-        cy.salvarEdicaoParticipante(`${dados.nome} ${dados.sobrenome}`)
+        cy.salvarEdicaoParticipante(`${dados.nome} ${dados.sobrenome}`, 'Confirmados')
 
 		// READ-UPDATE
 		cy.log('## READ-UPDATE ##')
@@ -795,6 +794,8 @@ describe('Participante', () => {
         // CREATE
         cy.log('## CREATE ##')
         
+        cy.loginTwygoAutomacao()
+		cy.alterarPerfil('administrador')
         cy.addParticipanteConteudo(nomeCurso)
 
         for (let i = 0; i < 5; i++) {
@@ -935,7 +936,7 @@ describe('Participante', () => {
 
         cy.importarParticipante('participantes.csv')
 
-        cy.validarStatusImportacao('participantes')
+        cy.validarStatusImportacao('participantes', 'Concluído')
 
         // READ
         cy.log('## READ ##')
@@ -1004,7 +1005,7 @@ describe('Participante', () => {
         cy.abaConfirmados()
         cy.editarParticipante(`${participante2.nome} ${participante2.sobrenome}`)
         cy.preencherDadosParticipante(dadosUpdate, { limpar: true })
-        cy.salvarEdicaoParticipante(`${dadosUpdate.nome} ${dadosUpdate.sobrenome}`)
+        cy.salvarEdicaoParticipante(`${dadosUpdate.nome} ${dadosUpdate.sobrenome}`, 'Confirmados')
 
 		// READ-UPDATE
 		cy.log('## READ-UPDATE ##')

--- a/cypress/e2e/cursoInstrutor.cy.js
+++ b/cypress/e2e/cursoInstrutor.cy.js
@@ -15,10 +15,10 @@ describe('Instrutor', () => {
 
     //Criar um usuário Instrutor e um curso 
     beforeEach(() => {
-        // Ativa o tratamento de exceção não capturada especificamente para este teste
-        Cypress.on('uncaught:exception', (err, runnable) => {
-            return false
-        }) 
+        // Ignora mensagens de erro conhecidas
+        cy.ignorarCapturaErros([
+            "Unexpected identifier 'id'"
+        ])
 
         // Gera um nome aleatório para o conteúdo e para a atividade
         nomeConteudo = fakerPT_BR.commerce.productName()
@@ -46,8 +46,7 @@ describe('Instrutor', () => {
     })
 
     afterEach(() => {
-        // Desativa o tratamento após o teste para evitar afetar outros testes
-        Cypress.removeAllListeners('uncaught:exception')
+        cy.ativarCapturaErros()
     })
 
     it('1. CRUD - Vincular instrutor em curso liberado', () => {

--- a/cypress/e2e/home.cy.js
+++ b/cypress/e2e/home.cy.js
@@ -1,18 +1,6 @@
 /// <reference types="cypress" />
 
 describe('pagina inicial', () => {
-	beforeEach(() => {
-        // Ativa o tratamento de exceção não capturada especificamente para este teste
-		Cypress.on('uncaught:exception', (err, runnable) => {
-            return false
-        })
-	})
-
-	afterEach(() => {
-		// Desativa o tratamento após o teste para evitar afetar outros testes
-		Cypress.removeAllListeners('uncaught:exception')
-	})
-
 	it('Twygo deve estar online e abrir pagina de login', () => {
 		cy.acessarPgLogin()
 	})

--- a/cypress/e2e/login.cy.js
+++ b/cypress/e2e/login.cy.js
@@ -1,38 +1,24 @@
 /// <reference types="cypress" />
 
 describe('login', () => {
-    beforeEach(() => {
-        // Ativa o tratamento de exceção não capturada especificamente para este teste
-		Cypress.on('uncaught:exception', (err, runnable) => {
-            return false
+    before(() => {
+        // Ignora mensagens de erro conhecidas
+        cy.ignorarCapturaErros([
+            "Unexpected identifier 'id'"
+        ])
+        
+        // Carrega os labels do arquivo JSON
+        cy.fixture('labels.json').then((labels) => {
+            Cypress.env('labels', labels)
         })
     })
 
     afterEach(() => {
-		// Desativa o tratamento após o teste para evitar afetar outros testes
-		Cypress.removeAllListeners('uncaught:exception')
-	})
+        cy.ativarCapturaErros()
+    })
 
     it('deve logar com sucesso', () => {
         cy.acessarPgLogin() 
-
-        cy.get('#user_email')
-            .type(Cypress.env('login'))
-    
-        cy.get('#user_password')
-            .type(Cypress.env('password'))
-
-        cy.contains('button', 'Entrar')
-            .should('be.visible')
-            .click()
-
-    	cy.contains('#page-breadcrumb', 'Dashboard')
-      		.should('be.visible')
-
-    	cy.contains('.name', Cypress.env('username'))
-      		.should('be.visible')
-
-    	cy.contains('#btn-profile', 'Aluno')
-      		.should('be.visible')
+        cy.loginTwygoAutomacao()
 	})
 })

--- a/cypress/e2e/perguntasPesquisa.cy.js
+++ b/cypress/e2e/perguntasPesquisa.cy.js
@@ -16,10 +16,10 @@ describe('Perguntas', () => {
     })
 
     beforeEach(() => { 
-        // Ativa o tratamento de exceção não capturada especificamente para este teste
-        Cypress.on('uncaught:exception', (err, runnable) => {
-            return false
-        })
+        // Ignora mensagens de erro conhecidas
+        cy.ignorarCapturaErros([
+            "Unexpected identifier 'id'"
+        ])
         
         // Massa de dados para criar questionário
         nomeQuestionario = fakerPT_BR.commerce.productName()
@@ -55,10 +55,8 @@ describe('Perguntas', () => {
     })
 
     afterEach(() => {
-		// Desativa o tratamento após o teste para evitar afetar outros testes
-		Cypress.removeAllListeners('uncaught:exception')
-	})
-
+        cy.ativarCapturaErros()
+    })
 
     it('1. CRUD pergunta do tipo "Texto"', () => {
         // Massa de dados para criar pergunta do tipo "Texto"

--- a/cypress/e2e/perguntasProva.cy.js
+++ b/cypress/e2e/perguntasProva.cy.js
@@ -16,11 +16,11 @@ describe('Perguntas', () => {
     })
 
     beforeEach(() => {  
-        // Ativa o tratamento de exceção não capturada especificamente para este teste
-        Cypress.on('uncaught:exception', (err, runnable) => {
-            return false
-        })
-       
+        // Ignora mensagens de erro conhecidas
+        cy.ignorarCapturaErros([
+            "Unexpected identifier 'id'"
+        ])
+        
         // Massa de dados para criar questionário
         nomeQuestionario = fakerPT_BR.commerce.productName()
         categorias1 = ['Atualidades', 'Entretenimento', 'Esportes', 'Tecnologia']
@@ -54,10 +54,8 @@ describe('Perguntas', () => {
     })
 
     afterEach(() => {
-		// Desativa o tratamento após o teste para evitar afetar outros testes
-		Cypress.removeAllListeners('uncaught:exception')
-	})
-
+        cy.ativarCapturaErros()
+    })
 
     it('1. CRUD pergunta do tipo "Texto"', () => {
         // Massa de dados para criar pergunta do tipo "Texto"

--- a/cypress/e2e/questionario.cy.js
+++ b/cypress/e2e/questionario.cy.js
@@ -29,10 +29,10 @@ describe('Questionário', () => {
 	})
 
     beforeEach(() => { 
-        // Ativa o tratamento de exceção não capturada especificamente para este teste
-        Cypress.on('uncaught:exception', (err, runnable) => {
-            return false
-        })
+        // Ignora mensagens de erro conhecidas
+        cy.ignorarCapturaErros([
+            "Unexpected identifier 'id'"
+        ])
         
         // Gerar um nome aleatório para o questionário
         nomeQuestionario = fakerPT_BR.commerce.productName()
@@ -55,11 +55,9 @@ describe('Questionário', () => {
     })
 
     afterEach(() => {
-		// Desativa o tratamento após o teste para evitar afetar outros testes
-		Cypress.removeAllListeners('uncaught:exception')
-	})
+        cy.ativarCapturaErros()
+    })
 
-    
     it('1. CRUD questionário tipo "Prova" com comentário aluno e parecer instrutor', () => {
         // Massa de dados para criação de questionário
         const dados = {

--- a/cypress/e2e/trilha.cy.js
+++ b/cypress/e2e/trilha.cy.js
@@ -45,11 +45,11 @@ describe('trilha', () => {
 	})
 
 	beforeEach(() => {
-		// Ativa o tratamento de exceção não capturada especificamente para este teste
-		Cypress.on('uncaught:exception', (err, runnable) => {
-		  	return false
-		})
-
+		// Ignora mensagens de erro conhecidas
+		cy.ignorarCapturaErros([
+			"Unexpected identifier 'id'"
+		], { ignoreScriptErrors: true })
+		
 		// Define o tipo de conteúdo
 		tipoConteudo = 'trilha'
 
@@ -73,10 +73,9 @@ describe('trilha', () => {
 		cy.listaConteudo(tipoConteudo, listaConteudos)
 		cy.excluirConteudo(null, tipoConteudo, listaConteudos)		
 	})
-	
+
 	afterEach(() => {
-		// Desativa o tratamento após o teste para evitar afetar outros testes
-		Cypress.removeAllListeners('uncaught:exception')
+		cy.ativarCapturaErros()
 	})
 	
 	it('1. CRUD trilha com dados default', () =>{

--- a/cypress/e2e/trilhaInscricao.cy.js
+++ b/cypress/e2e/trilhaInscricao.cy.js
@@ -73,6 +73,7 @@ describe('Participante', () => {
         const conteudo = {
             nome: nomeTrilha,
             descricao: `${fakerPT_BR.commerce.productDescription()} do evento ${nome}`,
+            exigeConfirmacao: true,
         }
 
         cy.addConteudo(tipoConteudo)
@@ -143,7 +144,7 @@ describe('Participante', () => {
         }
 
         cy.preencherDadosParticipante(dadosUpdate, { limpar: true })
-        cy.salvarEdicaoParticipante(`${dadosUpdate.nome} ${dadosUpdate.sobrenome}`)
+        cy.salvarEdicaoParticipante(`${dadosUpdate.nome} ${dadosUpdate.sobrenome}`, 'Confirmados') 
 
 		// READ-UPDATE
 		cy.log('## READ-UPDATE ##')
@@ -244,7 +245,7 @@ describe('Participante', () => {
         }
 
         cy.preencherDadosParticipante(dadosUpdate, { limpar: true })
-        cy.salvarEdicaoParticipante(`${dadosUpdate.nome} ${dadosUpdate.sobrenome}`)
+        cy.salvarEdicaoParticipante(`${dadosUpdate.nome} ${dadosUpdate.sobrenome}`, 'Confirmados')
 
 		// READ-UPDATE
 		cy.log('## READ-UPDATE ##')
@@ -321,7 +322,7 @@ describe('Participante', () => {
         }
 
         cy.preencherDadosParticipante(dadosUpdate, { limpar: true })
-        cy.salvarEdicaoParticipante(`${dados.nome} ${dados.sobrenome}`)
+        cy.salvarEdicaoParticipante(`${dados.nome} ${dados.sobrenome}`, 'Confirmados')
 
 		// READ-UPDATE
 		cy.log('## READ-UPDATE ##')
@@ -385,7 +386,7 @@ describe('Participante', () => {
         }
 
         cy.preencherDadosParticipante(dadosUpdate, { limpar: true })
-        cy.salvarEdicaoParticipante(`${dadosUpdate.nome} ${dadosUpdate.sobrenome}`)
+        cy.salvarEdicaoParticipante(`${dadosUpdate.nome} ${dadosUpdate.sobrenome}`, 'Confirmados')
 
 		// READ-UPDATE
 		cy.log('## READ-UPDATE ##')
@@ -443,7 +444,7 @@ describe('Participante', () => {
         }
 
         cy.preencherDadosParticipante(dadosUpdate, { limpar: true })
-        cy.salvarEdicaoParticipante(`${dados.nome} ${dados.sobrenome}`)
+        cy.salvarEdicaoParticipante(`${dados.nome} ${dados.sobrenome}`, 'Confirmados')
 
 		// READ-UPDATE
 		cy.log('## READ-UPDATE ##')
@@ -513,7 +514,7 @@ describe('Participante', () => {
         }
 
         cy.preencherDadosParticipante(dadosUpdate, { limpar: true })
-        cy.salvarEdicaoParticipante(`${dados.nome} ${dados.sobrenome}`)
+        cy.salvarEdicaoParticipante(`${dados.nome} ${dados.sobrenome}`, 'Confirmados')
 
 		// READ-UPDATE
 		cy.log('## READ-UPDATE ##')
@@ -587,7 +588,7 @@ describe('Participante', () => {
         }
 
         cy.preencherDadosParticipante(dadosUpdate, { limpar: true })
-        cy.salvarEdicaoParticipante(`${dados.nome} ${dados.sobrenome}`)
+        cy.salvarEdicaoParticipante(`${dados.nome} ${dados.sobrenome}`, 'Confirmados')
 
 		// READ-UPDATE
 		cy.log('## READ-UPDATE ##')

--- a/cypress/e2e/trilhaInscricao.cy.js
+++ b/cypress/e2e/trilhaInscricao.cy.js
@@ -45,11 +45,11 @@ describe('Participante', () => {
 	})
     
     beforeEach(() => {
-        // Ativa o tratamento de exceção não capturada especificamente para este teste
-		Cypress.on('uncaught:exception', (err, runnable) => {
-            return false
-        })
-
+        // Ignora mensagens de erro conhecidas
+        cy.ignorarCapturaErros([
+            "Unexpected identifier 'id'"
+        ], { ignoreScriptErrors: true })
+        
         // Define o tipo de conteúdo
 		tipoConteudo = 'trilha'
 
@@ -81,9 +81,8 @@ describe('Participante', () => {
     })
 
     afterEach(() => {
-		// Desativa o tratamento após o teste para evitar afetar outros testes
-		Cypress.removeAllListeners('uncaught:exception')
-	})
+        cy.ativarCapturaErros()
+    })
 
     it('1. CRUD participante default', () => {
         // Massa de dados

--- a/cypress/e2e/usuario.cy.js
+++ b/cypress/e2e/usuario.cy.js
@@ -45,20 +45,19 @@ describe('Usuário', () => {
 	})
     
     beforeEach(() => {
-        // Ativa o tratamento de exceção não capturada especificamente para este teste
-        Cypress.on('uncaught:exception', (err, runnable) => {
-            return false
-        })
-    
+        // Ignora mensagens de erro conhecidas
+        cy.ignorarCapturaErros([
+            "Unexpected identifier 'id'"
+        ])
+        
         // Obtém token autenticação, lista e exclui os usuários
         getAuthToken()
         cy.excluirUsuarioViaApi()
     })
 
     afterEach(() => {
-		// Desativa o tratamento após o teste para evitar afetar outros testes
-		Cypress.removeAllListeners('uncaught:exception')
-	})
+        cy.ativarCapturaErros()
+    })
 
     it('1. CRUD usuário default', () => {
         // Massa de dados

--- a/cypress/e2e/usuarioImportar.cy.js
+++ b/cypress/e2e/usuarioImportar.cy.js
@@ -282,6 +282,11 @@ describe('Importar Usuários', () => {
     })
 
     beforeEach(() => {
+        // Ignora mensagens de erro conhecidas
+        cy.ignorarCapturaErros([
+            "Unexpected identifier 'id'"
+        ])
+        
         // Exclui todos os usuários cadastrados (com excessão do usuário administrador principal)
         getAuthToken()
         cy.excluirUsuarioViaApi()
@@ -290,6 +295,10 @@ describe('Importar Usuários', () => {
         cy.loginTwygoAutomacao()
         cy.alterarPerfil('administrador')
         cy.acessarPgUsuarios()
+    })
+
+    afterEach(() => {
+        cy.ativarCapturaErros()
     })
 
     it('1. CRUD de usuário via importação com uma nova importação utilizando a opção de "Atualizar" os usuários já cadastrados', () => {


### PR DESCRIPTION
#### 🤖 FUNCIONALIDADE
.

#### 🎯 AUTOMAÇÃO
Removido uncaught:exception genérico, criado comando personalizado para que seja possível ignorar erros já mapeados, realizados ajustes nas execuções, inclusive para aqueles referente a exigência ou não de confirmação da inscrição, que em produção ainda é habilitado.

#### :heavy_check_mark: ATIVIDADE
{[Validações / análises / ajustes gerais / configurações / ambiente](https://app.artia.com/a/4874953/f/5152797/activities/27556601)}

#### :hammer_and_wrench: Tipo de mudança
 - [ ] Novos cenários (mudança que adiciona novos cenários automatizados)
 - [ ] Correção de quebras (alteração que corrige um problema)
 - [ ] Atualização de cenários (quando alterada a regra de negócio)
 - [X] Refatoração (Mudança no código que mantém o funcionamento como esperado)
 - [ ] Esta mudança requer uma atualização dos casos de testes no TestLink

#### :checkered_flag: CHECKLIST
- [X] Meu código segue as diretrizes de estilo deste projeto
- [X] Eu fiz uma autoavaliação do meu próprio código
- [X] Eu validei meus testes confirmando que minha implementação é eficaz ou que ela funciona como esperado
