### PR TITLE
Feat/registre se

### DIFF
--- a/cypress/e2e/registreSe.cy.js
+++ b/cypress/e2e/registreSe.cy.js
@@ -41,13 +41,6 @@ describe('Registre-se', () => {
         notificacoes: true
     }
 
-    before(() => {
-        // Carrega os labels do arquivo JSON
-        cy.fixture('labels.json').then((labels) => {
-            Cypress.env('labels', labels)
-        })
-    })
-
     beforeEach(() => {
         // Ignora mensagens de erro conhecidas
         cy.ignorarCapturaErros([
@@ -55,7 +48,7 @@ describe('Registre-se', () => {
         ])
 
         // Configura todos os campos omo obrigatórios
-        cy.configTodosCamposObrigatorios()
+        cy.configTodosCamposCustomizados('Habilitado e Obrigatório')
 
         // Obtém token autenticação, lista e exclui os usuários
         getAuthToken()
@@ -65,14 +58,6 @@ describe('Registre-se', () => {
         gerarSenha = gerarDados('senha')
         nome = gerarDados('nome')
         sobrenome = gerarDados('sobrenome')
-    })
-
-    afterEach(() => {
-        // Desabilita todos os campos customizados
-        cy.configNenhumCampoHabilitado()
-
-        // Ativa captura de erros
-        cy.ativarCapturaErros()
     })
 
     it('1. Registre-se', () => {
@@ -107,7 +92,6 @@ describe('Registre-se', () => {
         cy.log('## CREATE ##')
 
         cy.visit('/users/sign_up')
-
         cy.preencherDadosRegistreSe(dados)
         cy.validarDadosRegistreSe(dados)        // Validação no formulário antes de salvar
         cy.salvarRegistreSe()               

--- a/cypress/e2e/registreSe.cy.js
+++ b/cypress/e2e/registreSe.cy.js
@@ -1,0 +1,181 @@
+///reference types="cypress" />
+import { faker, fakerPT_BR } from '@faker-js/faker'
+import { gerarTelefone, gerarCEP } from '../support/utilsHelper'
+import formLogin from '../support/pageObjects/formLogin'
+let fakerbr = require('faker-br')
+
+describe('Registre-se', () => {
+    let senha, nome, sobrenome
+
+    let formDefault = {
+        email: '',
+        nome: '',
+        sobrenome: '',
+        cpf: '',
+        rg: '',
+        telPessoal: '',
+        celular: '',
+        cep: '',
+        endereco: '',
+        numero: '',
+        complemento: '',
+        bairro: '',
+        cidade: '',
+        estado: '',
+        pais: 'Brasil',
+        empresa: '',
+        ramo: '',
+        nrColaboradores: '',
+        site: '',
+        telComercial: '',
+        cargo: '',
+        area: '',
+        perfilColaborador: false,
+        perfilAdministrador: false,
+        perfilInstrutor: false,
+        perfilGestor: false,
+        perfilLiderEquipe: false,
+        comunidades: true,
+        notificacoes: true
+    }
+
+    before(() => {
+        // Carrega os labels do arquivo JSON
+        cy.fixture('labels.json').then((labels) => {
+            Cypress.env('labels', labels)
+        })
+    })
+
+    beforeEach(() => {
+        // Ignora mensagens de erro conhecidas
+        cy.ignorarCapturaErros([
+            "Unexpected identifier 'id'"
+        ])
+
+        // SuperAdmin - Marcar campos como obrigatórios para serem exibidos no formulário
+       
+        // Gerar senha, nome e sobrenome
+        senha = faker.internet.password()
+        nome = faker.person.firstName()
+        sobrenome = faker.person.lastName()
+    })
+
+    afterEach(() => {
+        cy.ativarCapturaErros()
+    })
+
+    it('1. Registre-se', () => {
+        //Massa de dados para criação do usuario
+        const dados = {
+            nome: nome,
+            sobrenome: sobrenome,
+            idioma: 'Português',
+            email: faker.internet.email({ firstName: nome, lastName: sobrenome, provider: 'teste.automatizado.com' }).toLowerCase(),
+            cpf: fakerbr.br.cpf(),
+            telPessoal: gerarTelefone('fixo'),
+            celular: gerarTelefone('celular'),
+            rg: faker.number.int( { min: 100000000, max: 999999999 } ),
+            cep: gerarCEP(),
+            endereco: fakerPT_BR.location.streetAddress(),
+            numero: faker.number.int( { min: 1, max: 9999 } ),
+            complemento: faker.word.words(2),
+            cidade: fakerPT_BR.location.city(),
+            bairro: fakerPT_BR.word.words(1),
+            estado: fakerPT_BR.location.state(),
+            pais: fakerPT_BR.location.country(),
+            empresa: faker.company.name(),
+            ramo: faker.commerce.department(),
+            nrColaboradores: faker.number.int( { min: 1, max: 9999 } ),
+            cargo: faker.commerce.department(),
+            senha: senha,
+            confirmarSenha: senha,
+            aceiteTermosPolitica: true
+        }
+
+        // CREATE
+        cy.log('## CREATE ##')
+
+        cy.visit('/users/sign_up')
+
+        cy.preencherDadosRegistreSe(dados)
+        cy.validarDadosRegistreSe(dados)        // Validação no formulário antes de salvar
+        cy.salvarRegistreSe()               
+
+        // READ
+        cy.log('## READ ##')
+
+        cy.loginTwygoAutomacao()
+		cy.alterarPerfil('administrador')
+        cy.acessarPgUsuarios()
+
+        cy.editarUsuario(`${dados.nome} ${dados.sobrenome}`)
+
+        let dadosParaValidar = { ...formDefault, ...dados }
+        cy.validarDadosUsuario(dados)
+
+        // Alterar senha do usuário
+        senha = fakerPT_BR.internet.password()
+        cy.voltar()
+        cy.resetSenhaUsuario(`${dados.nome} ${dados.sobrenome}`, senha)
+
+        // Inativação do usuário
+        cy.inativarUsuario(`${dados.nome} ${dados.sobrenome}`)
+
+        // Espera 5 segundos devido a renderização da tela
+        cy.wait(5000)
+
+        // Ativação do usuário
+        cy.ativarUsuario(`${dados.nome} ${dados.sobrenome}`)        
+
+        // UPDATE
+        cy.log('## UPDATE ##')
+
+        const dadosUpdate = {
+            nome: fakerPT_BR.person.firstName(),
+            sobrenome: fakerPT_BR.person.lastName(),
+            rg: fakerPT_BR.number.int({ min: 100000, max: 999999999 }),
+            telPessoal: `(${fakerPT_BR.string.numeric(2)}) ${fakerPT_BR.string.numeric(5)}-${fakerPT_BR.string.numeric(4)}`,
+            celular: `(${fakerPT_BR.string.numeric(2)}) ${fakerPT_BR.string.numeric(5)}-${fakerPT_BR.string.numeric(4)}`,
+            cep: fakerPT_BR.string.numeric(8),
+            endereco: fakerPT_BR.location.streetAddress(),
+            numero: fakerPT_BR.number.int( { min: 1, max: 9999 } ),
+            complemento: `Andar: ${fakerPT_BR.number.int( { min: 1, max: 20 } )}, Sala: ${fakerPT_BR.number.int( { min: 1, max: 20 } )}`,
+            bairro: fakerPT_BR.lorem.words(1),
+            cidade: fakerPT_BR.location.city(),
+            estado: fakerPT_BR.location.state(),
+            pais: 'Bósnia-Herzegovina',
+            empresa: fakerPT_BR.company.name(),
+            ramo: fakerPT_BR.lorem.words(1),
+            nrColaboradores: '31 - 100',
+            site: fakerPT_BR.internet.url(),
+            telComercial: `(${fakerPT_BR.string.numeric(2)}) ${fakerPT_BR.string.numeric(5)}-${fakerPT_BR.string.numeric(4)}`,
+            cargo: fakerPT_BR.person.jobTitle(),
+            area: fakerPT_BR.person.jobArea(),
+            perfilColaborador: false,
+            perfilAdministrador: false,
+            perfilInstrutor: false,
+            perfilGestor: false,
+            perfilLiderEquipe: false,
+            comunidades: false,
+            notificacoes: false            
+        }
+
+        cy.editarUsuario(`${dados.nome} ${dados.sobrenome}`)
+        cy.preencherDadosUsuario(dadosUpdate, { limpar: true })
+        cy.salvarUsuario(`${dadosUpdate.nome} ${dadosUpdate.sobrenome}`)
+
+		// READ-UPDATE
+		cy.log('## READ-UPDATE ##')
+
+		cy.editarUsuario(dadosUpdate.nome)
+
+        dadosParaValidar = { ...dadosParaValidar, ...dadosUpdate }
+		cy.validarDadosUsuario(dadosParaValidar)
+
+		// DELETE
+		cy.log('## DELETE ##')
+
+		cy.cancelarFormularioUsuario()
+		cy.excluirUsuario(`${dadosUpdate.nome} ${dadosUpdate.sobrenome}`)
+    })
+})

--- a/cypress/fixtures/labels.json
+++ b/cypress/fixtures/labels.json
@@ -345,6 +345,7 @@
     "superAdmin": {
         "boasVindas": "bem vindo",
         "msgOrientacao": "Selecione uma das opções no menu superior!",
-        "tituloPgCamposCustomizados": "Campos customizados da organização"
+        "tituloPgCamposCustomizados": "Campos customizados da organização",
+        "msgSucesso": "Alteração realizada com sucesso"
     }
 }

--- a/cypress/fixtures/labels.json
+++ b/cypress/fixtures/labels.json
@@ -341,5 +341,10 @@
     },
     "registreSe": {
         "msgSucesso": "Uma mensagem com o link de confirmação foi enviada para seu email. Por favor abra o link para ativar a sua conta."
+    },
+    "superAdmin": {
+        "boasVindas": "bem vindo",
+        "msgOrientacao": "Selecione uma das opções no menu superior!",
+        "tituloPgCamposCustomizados": "Campos customizados da organização"
     }
 }

--- a/cypress/fixtures/labels.json
+++ b/cypress/fixtures/labels.json
@@ -338,5 +338,8 @@
         "textoModalInativar": "Todas as consultas que usam essa chave de API serão interrompidas. Tem certeza que deseja continuar?",
         "msgSucessoInativar": "Chave de API inativada com sucesso",
         "msgSucessoAtivar": "Chave de API ativada com sucesso"
+    },
+    "registreSe": {
+        "msgSucesso": "Uma mensagem com o link de confirmação foi enviada para seu email. Por favor abra o link para ativar a sua conta."
     }
 }

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -17,6 +17,7 @@ import formCobrancaAutomatica from "./pageObjects/formCobrancaAutomatica"
 import formCuponsVouchers from "./pageObjects/formCuponsVouchers"
 import formIntegracoes from "./pageObjects/formIntegracoes"
 import formRegistreSe from "./pageObjects/formRegistreSe"
+import formSuperAdmin from "./pageObjects/formSuperAdmin"
 import { fakerPT_BR } from "@faker-js/faker"
 import 'cypress-real-events/support'
 import moment from 'moment'
@@ -3772,4 +3773,96 @@ Cypress.Commands.add('salvarRegistreSe', () => {
   // Valida a mensagem de sucesso
   cy.contains('.flash.notice', msgSucesso)
     .should('be.visible')
+})
+
+Cypress.Commands.add('acessarSuperAdmin', (opcao) => {
+  const labels = Cypress.env('labels')
+  const { boasVindas, msgOrientacao, tituloPgCamposCustomizados } = labels.superAdmin
+
+  cy.visit('/admin')
+
+  // Validar a página de super admin
+  cy.contains('h1', boasVindas)
+    .should('be.visible')
+  
+  cy.contains('p', msgOrientacao)
+    .should('be.visible')
+  
+  switch (opcao) {
+    case 'Campos customizados':
+      formSuperAdmin.acessarCamposCustomizados()
+
+      // Validar a página de campos customizados
+      cy.contains('.page-header h1', tituloPgCamposCustomizados)
+        .should('be.visible')
+      break
+
+    default:
+      throw new Error(`Opção inválida: ${opcao}. Utilize 'Campos customizados'`)
+  }
+})
+
+Cypress.Commands.add('configTodosCamposObrigatorios', () => {
+  const habilitarTodosCampos = {
+    phone: ['habilitar', 'obrigatório'],
+    cpf: ['habilitar', 'obrigatório'],
+    rg: ['habilitar', 'obrigatório'],
+    address: ['habilitar', 'obrigatório'],
+    address2: ['habilitar', 'obrigatório'],
+    city: ['habilitar', 'obrigatório'],
+    district: ['habilitar', 'obrigatório'],
+    address_number: ['habilitar', 'obrigatório'],
+    zip_code: ['habilitar', 'obrigatório'],
+    state: ['habilitar', 'obrigatório'],
+    country: ['habilitar', 'obrigatório'],
+    manager: 'habilitar',
+    team: 'habilitar',
+    department: ['habilitar', 'obrigatório'],
+    enterprise: ['habilitar', 'obrigatório'],
+    business_line: ['habilitar', 'obrigatório'],
+    number_of_employees: ['habilitar', 'obrigatório'],
+    role: ['habilitar', 'obrigatório'],
+  }
+
+  cy.loginTwygoAutomacao()
+  cy.alterarPerfil('administrador')
+  cy.acessarSuperAdmin('Campos customizados')
+  formSuperAdmin.preencherCamposCustomizados(Cypress.env('orgId'))
+  formSuperAdmin.configurarCamposCustomizados(habilitarTodosCampos)    
+  formSuperAdmin.salvar()
+  cy.get('.flash.success').should('contain.text', 'Alteração realizada com sucesso')
+  cy.acessarPgListaConteudos()
+  cy.logout()
+})
+
+Cypress.Commands.add('configNenhumCampoHabilitado', () => {
+  const desabilitarTodosCampos = {
+    phone: 'desabilitar',
+    cpf: 'desabilitar',
+    rg: 'desabilitar',
+    address: 'desabilitar',
+    address2: 'desabilitar',
+    city: 'desabilitar',
+    district: 'desabilitar',
+    address_number: 'desabilitar',
+    zip_code: 'desabilitar',
+    state: 'desabilitar',
+    country: 'desabilitar',
+    manager: 'desabilitar',
+    team: 'desabilitar',
+    department: 'desabilitar',
+    enterprise: 'desabilitar',
+    business_line: 'desabilitar',
+    number_of_employees: 'desabilitar',
+    role: 'desabilitar'
+  }
+
+  cy.logout()
+  cy.loginTwygoAutomacao()
+  cy.alterarPerfil('administrador')
+  cy.acessarSuperAdmin('Campos customizados')
+  formSuperAdmin.preencherCamposCustomizados(Cypress.env('orgId'))
+  formSuperAdmin.configurarCamposCustomizados(desabilitarTodosCampos)    
+  formSuperAdmin.salvar()
+  cy.get('.flash.success').should('contain.text', 'Alteração realizada com sucesso')
 })

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -16,6 +16,7 @@ import formConteudosAmbienteAdicional from "./pageObjects/formConteudosAmbienteA
 import formCobrancaAutomatica from "./pageObjects/formCobrancaAutomatica"
 import formCuponsVouchers from "./pageObjects/formCuponsVouchers"
 import formIntegracoes from "./pageObjects/formIntegracoes"
+import formRegistreSe from "./pageObjects/formRegistreSe"
 import { fakerPT_BR } from "@faker-js/faker"
 import 'cypress-real-events/support'
 import moment from 'moment'
@@ -3746,4 +3747,29 @@ Cypress.Commands.add('excluirTodasChavesApi', () => {
       })
     }
   })
+})
+
+Cypress.Commands.add('preencherDadosRegistreSe', (dados, opcoes = { limpar: false }) => {
+  Object.keys(dados).forEach(nomeCampo => {
+    const valor = dados[nomeCampo]
+    formRegistreSe.preencherCampo(nomeCampo, valor, opcoes)
+  })
+})
+
+Cypress.Commands.add('validarDadosRegistreSe', (dados) => {
+  Object.keys(dados).forEach(nomeCampo => {
+    const valor = dados[nomeCampo] !== undefined ? dados[nomeCampo] : valorDefault
+    formRegistreSe.validarCampo(nomeCampo, valor)
+  })
+})
+
+Cypress.Commands.add('salvarRegistreSe', () => {
+  const labels = Cypress.env('labels')
+  const { msgSucesso } = labels.registreSe
+
+  formRegistreSe.salvar()
+
+  // Valida a mensagem de sucesso
+  cy.contains('.flash.notice', msgSucesso)
+    .should('be.visible')
 })

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -19,6 +19,24 @@ import './commands'
 // Alternatively you can use CommonJS syntax:
 // require('./commands')
 
-beforeEach(() => {
+before(() => {
+  // Define resolução padrão
   cy.viewport(1920, 1080)
+
+  // Carrega os labels do arquivo JSON
+  cy.fixture('labels.json').then((labels) => {
+    Cypress.env('labels', labels)
+  })
+
+  // Ignora mensagens de erro conhecidas
+  cy.ignorarCapturaErros([
+    "Unexpected identifier 'id'"
+  ])
+
+  cy.configTodosCamposCustomizados('Desabilitado')
+})
+
+afterEach(() => {
+  // Ativa captura de erros
+  cy.ativarCapturaErros()
 })

--- a/cypress/support/helpers/geradorDados.js
+++ b/cypress/support/helpers/geradorDados.js
@@ -1,19 +1,23 @@
-//TODO em andamento em paralelo 
-const { faker } = require('@faker-js/faker')
+const { faker, fakerPT_BR } = require('@faker-js/faker')
+const fakerbr = require('faker-br')
 
-function gerarDados(tipo) {
-    switch (tipo) {
+function gerarDados(dado, nome = '', sobrenome = '', dominio = 'automacao.com', regiao = null, tipo = 'celular') {
+    switch (dado) {
         case 'nome':
-            return faker.person.firstName();
+            return faker.person.firstName()
         case 'sobrenome':
-            return faker.person.lastName();
+            return faker.person.lastName()
         case 'nomeCompleto':
-            return `${faker.person.firstName()} ${faker.person.lastName()}`;
-        case 'email'(nome, sobrenome, dominio = 'automacao.com'):
-            const nome = nome.toLowerCase()
-            const sobrenome = sobrenome.toLowerCase()
-            return `${nome}.${sobrenome}@${dominio}`
-        case 'celular'(tipo):
+            return `${faker.person.firstName()} ${faker.person.lastName()}`
+        case 'email':
+            if (nome && sobrenome) {
+                const nomeLower = nome.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f']/g, '')
+                const sobrenomeLower = sobrenome.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f']/g, '')
+                return `${nomeLower}.${sobrenomeLower}@${dominio}`
+            } else {
+                return faker.internet.email()
+            }
+        case 'telefone':
             const dddsValidos = [
                 '11', '12', '13', '14', '15', '16', '17', '18', '19', // São Paulo
                 '21', '22', '24', // Rio de Janeiro
@@ -43,13 +47,19 @@ function gerarDados(tipo) {
             throw new Error(`Tipo de telefone inválido: ${tipo}. Utilize 'celular' ou 'fixo'`)
             }
         case 'endereco':
-            return faker.location.streetAddress();
+            return fakerPT_BR.location.streetAddress()
+        case 'numero':
+            return faker.number.int( { min: 1, max: 9999 } )
+        case 'complemento':
+            return `Andar: ${faker.number.int( { min: 1, max: 20 } )}, Apto: ${faker.number.int( { min: 100, max: 200 } )}`
+        case 'bairro':
+            return fakerPT_BR.location.streetAddress()
         case 'cidade':
-            return faker.location.city();
+            return fakerPT_BR.location.city()
         case 'estado':
-            return faker.location.state();
+            return fakerPT_BR.location.state()
         case 'pais':
-            return faker.location.country();
+            return faker.location.country()
         case 'cep':
             // Definindo as regiões postais e seus respectivos intervalos de CEP
             const regioesPostais = {
@@ -78,9 +88,27 @@ function gerarDados(tipo) {
             // Montando o CEP completo
             const cep = `${regioesPostais[regiaoEscolhida]}${subRegiao}${setor}${subSetor}${divisorSubSetor}-${identificadorDistribuicao}`
 
-            return cep        
+            return cep
+        case 'senha':
+            return faker.internet.password()
+        case 'cpf':
+            return fakerbr.br.cpf()
+        case 'rg':
+            return faker.number.int( { min: 100000000, max: 999999999 } )  
+        case 'empresa':
+            return faker.company.name()
+        case 'ramo':
+            return faker.person.jobArea()
+        case 'cargo':
+            return faker.person.jobTitle()
+        case 'area':
+            return faker.person.jobType()
+        case 'nrColaboradores':
+            return faker.number.int( { min: 1, max: 9999 } )
+        case 'site':
+            return faker.internet.url()
         default:
-            throw new Error(`Tipo de dado não suportado: ${tipo}`);
+            throw new Error(`Tipo de dado não suportado: ${dado}`)
     }
 }
 

--- a/cypress/support/helpers/geradorDados.js
+++ b/cypress/support/helpers/geradorDados.js
@@ -1,0 +1,89 @@
+//TODO em andamento em paralelo 
+const { faker } = require('@faker-js/faker')
+
+function gerarDados(tipo) {
+    switch (tipo) {
+        case 'nome':
+            return faker.person.firstName();
+        case 'sobrenome':
+            return faker.person.lastName();
+        case 'nomeCompleto':
+            return `${faker.person.firstName()} ${faker.person.lastName()}`;
+        case 'email'(nome, sobrenome, dominio = 'automacao.com'):
+            const nome = nome.toLowerCase()
+            const sobrenome = sobrenome.toLowerCase()
+            return `${nome}.${sobrenome}@${dominio}`
+        case 'celular'(tipo):
+            const dddsValidos = [
+                '11', '12', '13', '14', '15', '16', '17', '18', '19', // São Paulo
+                '21', '22', '24', // Rio de Janeiro
+                '27', '28', // Espírito Santo
+                '31', '32', '33', '34', '35', '37', '38', // Minas Gerais
+                '41', '42', '43', '44', '45', '46', // Paraná
+                '47', '48', '49', // Santa Catarina
+                '51', '53', '54', '55', // Rio Grande do Sul
+                '61', // Distrito Federal
+                '62', '64', '65', '66', '67', // Goiás e Mato Grosso
+                '68', '69', // Acre e Rondônia
+                '71', '73', '74', '75', '77', // Bahia
+                '79', // Sergipe
+                '81', '82', '83', '84', '85', '86', '87', '88', '89', // Pernambuco, Alagoas, Paraíba, Rio Grande do Norte, Ceará, Piauí
+                '91', '92', '93', '94', '95', '96', '97', '98', '99' // Pará, Amazonas, Roraima, Amapá, Maranhão
+            ]
+        
+            const ddd = dddsValidos[Math.floor(Math.random() * dddsValidos.length)]
+        
+            if (tipo === 'celular') {
+            const numero = Math.floor(Math.random() * 100000000).toString().padStart(8, '0')
+            return `(${ddd}) 9${numero.substring(0, 4)}-${numero.substring(4)}`
+            } else if (tipo === 'fixo') {
+            const numero = Math.floor(Math.random() * 100000000).toString().padStart(8, '0')
+            return `(${ddd}) ${numero.substring(0, 4)}-${numero.substring(4)}`
+            } else {
+            throw new Error(`Tipo de telefone inválido: ${tipo}. Utilize 'celular' ou 'fixo'`)
+            }
+        case 'endereco':
+            return faker.location.streetAddress();
+        case 'cidade':
+            return faker.location.city();
+        case 'estado':
+            return faker.location.state();
+        case 'pais':
+            return faker.location.country();
+        case 'cep':
+            // Definindo as regiões postais e seus respectivos intervalos de CEP
+            const regioesPostais = {
+                0: '0', // Grande São Paulo
+                1: '1', // Interior de São Paulo
+                2: '2', // Rio de Janeiro e Espírito Santo
+                3: '3', // Minas Gerais
+                4: '4', // Bahia e Sergipe
+                5: '5', // Pernambuco, Alagoas, Paraíba e Rio Grande do Norte
+                6: '6', // Ceará, Piauí, Maranhão, Pará, Amazonas, Acre, Amapá e Roraima
+                7: '7', // Distrito Federal, Goiás, Tocantins, Mato Grosso, Mato Grosso do Sul e Rondônia
+                8: '8', // Paraná e Santa Catarina
+                9: '9'  // Rio Grande do Sul
+            }
+
+            // Se uma região específica for fornecida, use-a; caso contrário, escolha uma aleatória
+            const regiaoEscolhida = regiao !== null ? regiao : faker.helpers.arrayElement(Object.keys(regioesPostais))
+
+            // Gerando os outros dígitos do CEP
+            const subRegiao = faker.number.int({ min: 0, max: 9 })
+            const setor = faker.number.int({ min: 0, max: 9 })
+            const subSetor = faker.number.int({ min: 0, max: 9 })
+            const divisorSubSetor = faker.number.int({ min: 0, max: 9 })
+            const identificadorDistribuicao = faker.number.int({ min: 0, max: 999 }).toString().padStart(3, '0')
+
+            // Montando o CEP completo
+            const cep = `${regioesPostais[regiaoEscolhida]}${subRegiao}${setor}${subSetor}${divisorSubSetor}-${identificadorDistribuicao}`
+
+            return cep        
+        default:
+            throw new Error(`Tipo de dado não suportado: ${tipo}`);
+    }
+}
+
+module.exports = {
+    gerarDados
+}

--- a/cypress/support/pageObjects/formLogin.js
+++ b/cypress/support/pageObjects/formLogin.js
@@ -1,0 +1,39 @@
+class formLogin {
+    elementos = {
+        login: {
+            seletor: '#user_email',
+            tipo: 'input'
+        },
+        senha: {
+            seletor: '#user_password',
+            tipo: 'input'
+        },
+        entrar: {
+            seletor: '#user_submit',
+            tipo: 'button'
+        },
+        esqueciSenha: {
+            seletor: '#forgot-password',
+            tipo: 'link'
+        },
+        reenviarEmailConfirmacao: {
+            seletor: '#resend-confirmation',
+            tipo: 'link'
+        },
+        registreSe: {
+            seletor: '#register_button',
+            tipo: 'link'
+        }
+    }
+
+    entrar() {
+        cy.get(this.elementos.entrar.seletor)
+            .click()
+    }
+
+    registreSe() {
+        cy.get(this.elementos.registreSe.seletor)
+            .click()
+    }
+}
+export default new formLogin

--- a/cypress/support/pageObjects/formRegistreSe.js
+++ b/cypress/support/pageObjects/formRegistreSe.js
@@ -143,7 +143,7 @@ class formRegistreSe {
                         .click()
                         .clear()
                         .wait(2000)
-                        .type(valorFinal, {delay: 200})
+                        .type(valorFinal, {delay: 100})
                     break
                 case 'checkbox':
 					if (valorFinal === true) {

--- a/cypress/support/pageObjects/formRegistreSe.js
+++ b/cypress/support/pageObjects/formRegistreSe.js
@@ -1,0 +1,208 @@
+class formRegistreSe {
+    elementos = {
+        nome: {
+            seletor: '#first-name',
+            tipo: 'input'
+        },
+        sobrenome: {
+            seletor: '#last-name',
+            tipo: 'input'
+        },
+        idioma: {
+            seletor: '#user_language',
+            tipo: 'select'
+        },
+        email: {
+            seletor: '#cadastro_email',
+            tipo: 'input'
+        },
+        cpf: {
+            seletor: '#cadastro_cpf',
+            tipo: 'input'
+        },
+        telPessoal: {
+            seletor: '#phone1',
+            tipo: 'input'
+        },
+        celular: {
+            seletor: '#cell_phone',
+            tipo: 'input'
+        },
+        rg: {
+            seletor: '#rg',
+            tipo: 'input'
+        },
+        cep: {
+            seletor: '#zip_code',
+            tipo: 'input-zipcode'
+        },
+        endereco: {
+            seletor: '#address',
+            tipo: 'input-endereco'
+        },
+        numero: {
+            seletor: '#address_number',
+            tipo: 'input'
+        },
+        complemento: {
+            seletor: '#address2',
+            tipo: 'input'
+        },
+        cidade: {
+            seletor: '#city',
+            tipo: 'input'
+        },
+        bairro: {
+            seletor: '#district',
+            tipo: 'input'
+        },
+        estado: {
+            seletor: '#state',
+            tipo: 'input'
+        },
+        pais: {
+            seletor: '#country',
+            tipo: 'input'
+        },
+        empresa: {
+            seletor: '#enterprise',
+            tipo: 'input'
+        },
+        ramo: {
+            seletor: '#business_line',
+            tipo: 'input'
+        },
+        nrColaboradores: {
+            seletor: '#number_of_employees',
+            tipo: 'input'
+        },
+        cargo: {
+            seletor: '#role',
+            tipo: 'input'
+        },
+        senha: {
+            seletor: '#user-pass',
+            tipo: 'input'
+        },
+        confirmarSenha: {
+            seletor: '#user-pass-confirmation',
+            tipo: 'input'
+        },
+        aceiteTermosPolitica: {
+            seletorCheck: '#check_click',
+            seletorUncheck: '#check_unclick',
+            tipo: 'checkbox'
+        },
+        cadastreMe: {
+            seletor: '#button-confirm-signup',
+            tipo: 'button'
+        },
+    }
+
+    salvar() {
+        cy.get(this.elementos.cadastreMe.seletor)
+            .click()
+    }
+
+    preencherCampo(nomeCampo, valor, opcoes = { limpar: false }) {
+		const campo = this.elementos[nomeCampo]
+
+		if (!campo) {
+			throw new Error(`Campo ${nomeCampo} não encontrado`)
+		}
+
+		const { seletor, seletorCheck, seletorUncheck, tipo, default: valorDefault } = campo
+
+		let valorFinal = valor !== undefined ? valor : valorDefault
+
+		if (opcoes.limpar && tipo === 'input') {
+			cy.get(seletor)
+				.clear()
+			if (valorFinal === '') {
+				return
+			}
+		}
+
+		if (valorFinal === '' && tipo === 'input') {
+			cy.get(seletor)
+				.clear()
+		} else if (valorFinal !== undefined) {
+			switch (tipo) {
+				case 'input':
+                    cy.get(seletor)
+                        .type(valorFinal)
+                    break
+                case 'input-zipcode':
+                    cy.get(seletor)
+                        .clear()
+                        .type(valorFinal)
+                        .wait(2000)
+                    break
+                case 'input-endereco':
+                    cy.get(seletor)
+                        .click()
+                        .clear()
+                        .wait(2000)
+                        .type(valorFinal, {delay: 200})
+                    break
+                case 'checkbox':
+					if (valorFinal === true) {
+                        cy.get(seletorCheck)
+                            .click()
+                    } else if (valorFinal === false) {
+                        cy.get(seletorUncheck)
+                            .click()
+                    }                
+					break
+				case 'select':
+					cy.get(seletor)
+						.select(valorFinal)
+					break
+				default:
+					throw new Error(`Tipo de campo ${tipo} não suportado`)
+			}
+		} else {
+			throw new Error(`Campo ${nomeCampo} não pode ser preenchido com valor ${valorFinal}`)
+		}
+	}
+
+    validarCampo(nomeCampo, valor) {
+		const campo = this.elementos[nomeCampo]
+
+		if (!campo) {
+			throw new Error(`Campo ${nomeCampo} não encontrado`)
+		}
+
+		const { seletor, tipo, default: valorDefault } = campo
+
+		let valorFinal = valor !== undefined ? valor : valorDefault
+
+		switch (tipo) {
+			case 'input':
+            case 'input-endereco':
+                cy.get(seletor)
+					.should('have.value', valorFinal)
+				break
+            case 'input-zipcode':
+                cy.get(seletor)
+                    .invoke('val')
+                    .should(val => {
+                        expect(val).to.satisfy(val => 
+                            val === '' || /\d{5}-\d{3}/.test(val),
+                        )
+                    })
+                break
+            case 'checkbox':
+				// não validar nada
+				break
+			case 'select':
+				cy.get(seletor)
+					.find('option:selected')
+					.should('have.text', valorFinal)
+				break
+			default:
+				throw new Error(`Tipo de campo ${tipo} não suportado`)
+		}
+	}
+}
+export default new formRegistreSe

--- a/cypress/support/pageObjects/formSuperAdmin.js
+++ b/cypress/support/pageObjects/formSuperAdmin.js
@@ -1,0 +1,232 @@
+class formSuperAdmin {
+    elementos = {
+        abaOutros: {
+            seletor: 'a.dropdown-toggle:contains("Outros")'
+        },
+        menuDropdown: {
+            enviarNewsletter: {
+                seletor: 'a[href="/admin/newsletter"]'
+            },
+            liberarEventosPublicos: {
+                seletor: 'a[href="/admin/public_events"]'
+            },
+            mudarTipoOrganizacao: {
+                seletor: 'a[href="/admin/origin_type"]'
+            },
+            adicionarChaveFluxAPI: {
+                seletor: 'a[href="/admin/flux_api_key"]'
+            },
+            camposCustomizados: {
+                seletor: 'a[href="/admin/organization_custom_participant_fields"]'
+            },
+            ativarDesativarConfiguracoes: {
+                seletor: 'a[href="/admin/enable_or_disable_settings_in_organization"]'
+            },
+            limpezaInativacaoOrganizacoes: {
+                seletor: 'a[href="/admin/organization_cleaning_and_inactivation"]'
+            },
+            exigirNovoAceiteTermos: {
+                seletor: 'a[href="/admin/update_default_term_twygo"]'
+            },
+            liberarAcessosViews: {
+                seletor: 'a[href="/admin/release_access_to_views"]'
+            }
+        },
+        // Campos customizados
+        idOrg : {
+            seletor: '#organization_id'
+        },
+        btnPreencher: {
+            seletor: 'button:contains("Preencher")'
+        },
+        phone: {
+            seletorHabilitar: 'input#without_list_phone_enabled[type="checkbox"]',
+            seletorObrigatorio: 'input#without_list_phone_required[type="checkbox"]'
+        },
+        cpf: {
+            seletorHabilitar: 'input#without_list_cpf_enabled[type="checkbox"]',
+            seletorObrigatorio: 'input#without_list_cpf_required[type="checkbox"]'
+        },
+        rg: {
+            seletorHabilitar: 'input#without_list_rg_enabled[type="checkbox"]',
+            seletorObrigatorio: 'input#without_list_rg_required[type="checkbox"]'
+        },
+        address: {
+            seletorHabilitar: 'input#without_list_address_enabled[type="checkbox"]',
+            seletorObrigatorio: 'input#without_list_address_required[type="checkbox"]'
+        },
+        address2: {
+            seletorHabilitar: 'input#without_list_address2_enabled[type="checkbox"]',
+            seletorObrigatorio: 'input#without_list_address2_required[type="checkbox"]'
+        },
+        city: {
+            seletorHabilitar: 'input#without_list_city_enabled[type="checkbox"]',
+            seletorObrigatorio: 'input#without_list_city_required[type="checkbox"]'
+        },
+        district: {
+            seletorHabilitar: 'input#without_list_district_enabled[type="checkbox"]',
+            seletorObrigatorio: 'input#without_list_district_required[type="checkbox"]'
+        },
+        address_number: {
+            seletorHabilitar: 'input#without_list_address_number_enabled[type="checkbox"]',
+            seletorObrigatorio: 'input#without_list_address_number_required[type="checkbox"]'
+        },
+        zip_code: {
+            seletorHabilitar: 'input#without_list_zip_code_enabled[type="checkbox"]',
+            seletorObrigatorio: 'input#without_list_zip_code_required[type="checkbox"]'
+        },
+        state: {
+            seletorHabilitar: 'input#without_list_state_enabled[type="checkbox"]',
+            seletorObrigatorio: 'input#without_list_state_required[type="checkbox"]'
+        },
+        country: {
+            seletorHabilitar: 'input#without_list_country_enabled[type="checkbox"]',
+            seletorObrigatorio: 'input#without_list_country_required[type="checkbox"]'
+        },
+        manager: {
+            seletorHabilitar: 'input#without_list_manager_enabled[type="checkbox"]',
+            seletorObrigatorio: 'input#without_list_manager_required[type="checkbox"]'
+        },
+        team: {
+            seletorHabilitar: 'input#without_list_team_enabled[type="checkbox"]',
+            seletorObrigatorio: 'input#without_list_team_required[type="checkbox"]'
+        },
+        department: {
+            seletorHabilitar: 'input#without_list_department_enabled[type="checkbox"]',
+            seletorObrigatorio: 'input#without_list_department_required[type="checkbox"]'
+        },
+        enterprise: {
+            seletorHabilitar: 'input#with_list_enterprise_enabled[type="checkbox"]',
+            seletorObrigatorio: 'input#with_list_enterprise_required[type="checkbox"]',
+            seletorAdministracao: 'input#with_list_enterprise_show_on_admin[type="checkbox"]'
+        },
+        business_line: {
+            seletorHabilitar: 'input#with_list_business_line_enabled[type="checkbox"]',
+            seletorObrigatorio: 'input#with_list_business_line_required[type="checkbox"]',
+            seletorAdministracao: 'input#with_list_business_line_show_on_admin[type="checkbox"]'
+        },
+        number_of_employees: {
+            seletorHabilitar: 'input#with_list_number_of_employees_enabled[type="checkbox"]',
+            seletorObrigatorio: 'input#with_list_number_of_employees_required[type="checkbox"]',
+            seletorAdministracao: 'input#with_list_number_of_employees_show_on_admin[type="checkbox"]'
+        },
+        role: {
+            seletorHabilitar: 'input#with_list_role_enabled[type="checkbox"]',
+            seletorObrigatorio: 'input#with_list_role_required[type="checkbox"]',
+            seletorAdministracao: 'input#with_list_role_show_on_admin[type="checkbox"]'
+        },
+        btnSalvar: {
+            seletor: 'button.btn-success:contains("Salvar")'
+        },
+    }
+
+    acessarAbaOutros() {
+        cy.get(this.elementos.abaOutros.seletor)
+            .click()
+    }
+
+    acessarEnviarNewsletter() {
+        this.acessarAbaOutros()
+        cy.get(this.elementos.menuDropdown.enviarNewsletter.seletor)
+            .click()
+    }
+
+    acessarLiberarEventosPublicos() {
+        this.acessarAbaOutros()
+        cy.get(this.elementos.menuDropdown.liberarEventosPublicos.seletor)
+            .click()
+    }
+
+    acessarMudarTipoOrganizacao() {
+        this.acessarAbaOutros()
+        cy.get(this.elementos.menuDropdown.mudarTipoOrganizacao.seletor)
+            .click()
+    }
+
+    acessarAdicionarChaveFluxAPI() {
+        this.acessarAbaOutros()
+        cy.get(this.elementos.menuDropdown.adicionarChaveFluxAPI.seletor)
+            .click()
+    }
+
+    acessarCamposCustomizados() {
+        this.acessarAbaOutros()
+        cy.get(this.elementos.menuDropdown.camposCustomizados.seletor)
+            .click()
+    }
+
+    acessarAtivarDesativarConfiguracoes() {
+        this.acessarAbaOutros()
+        cy.get(this.elementos.menuDropdown.ativarDesativarConfiguracoes.seletor)
+            .click()
+    }
+
+    acessarLimpezaInativacaoOrganizacoes() {
+        this.acessarAbaOutros()
+        cy.get(this.elementos.menuDropdown.limpezaInativacaoOrganizacoes.seletor)
+            .click()
+    }
+
+    acessarExigirNovoAceiteTermos() {
+        this.acessarAbaOutros()
+        cy.get(this.elementos.menuDropdown.exigirNovoAceiteTermos.seletor)
+            .click()
+    }
+
+    acessarLiberarAcessosViews() {
+        this.acessarAbaOutros()
+        cy.get(this.elementos.menuDropdown.liberarAcessosViews.seletor)
+            .click()
+    }
+
+    preencherCamposCustomizados(idOrg) {
+        cy.get(this.elementos.idOrg.seletor)
+            .type(idOrg)
+        cy.get(this.elementos.btnPreencher.seletor)
+            .click()
+        cy.wait(500); // Aguarda um pouco para garantir que a ação seja processada
+    }
+
+    configurarCamposCustomizados(camposOrg) {
+        Object.keys(camposOrg).forEach(campo => {
+            const acoes = Array.isArray(camposOrg[campo]) ? camposOrg[campo] : [camposOrg[campo]];
+            const elemento = this.elementos[campo];
+    
+            if (!elemento) {
+                throw new Error(`Campo ${campo} não encontrado nos elementos.`);
+            }
+    
+            acoes.forEach(acao => {
+                if (acao === 'habilitar' || acao === 'desabilitar') {
+                    cy.get(elemento.seletorHabilitar).then($el => {
+                        const estadoAtual = $el.prop('checked');
+                        const estadoDesejado = acao === 'habilitar';
+    
+                        if (estadoAtual !== estadoDesejado) {
+                            cy.wrap($el).click({ force: true });
+                            cy.wait(250); // Aguarda um pouco para garantir que a ação seja processada
+                        }
+                    });
+                } else if (acao === 'obrigatório' || acao === 'não obrigatório') {
+                    cy.get(elemento.seletorObrigatorio).then($el => {
+                        const estadoAtual = $el.prop('checked');
+                        const estadoDesejado = acao === 'obrigatório';
+    
+                        if (estadoAtual !== estadoDesejado) {
+                            cy.wrap($el).click({ force: true });
+                            cy.wait(250); // Aguarda um pouco para garantir que a ação seja processada
+                        }
+                    });
+                } else {
+                    throw new Error(`Ação ${acao} não reconhecida para o campo ${campo}.`);
+                }
+            });
+        });
+    }
+
+    salvar() {
+        cy.get(this.elementos.btnSalvar.seletor)
+            .click()
+    }
+}
+export default new formSuperAdmin

--- a/cypress/support/pageObjects/formSuperAdmin.js
+++ b/cypress/support/pageObjects/formSuperAdmin.js
@@ -182,46 +182,48 @@ class formSuperAdmin {
     preencherCamposCustomizados(idOrg) {
         cy.get(this.elementos.idOrg.seletor)
             .type(idOrg)
+
         cy.get(this.elementos.btnPreencher.seletor)
             .click()
-        cy.wait(500); // Aguarda um pouco para garantir que a ação seja processada
+            
+        cy.wait(500)
     }
 
     configurarCamposCustomizados(camposOrg) {
         Object.keys(camposOrg).forEach(campo => {
-            const acoes = Array.isArray(camposOrg[campo]) ? camposOrg[campo] : [camposOrg[campo]];
-            const elemento = this.elementos[campo];
+            const acoes = Array.isArray(camposOrg[campo]) ? camposOrg[campo] : [camposOrg[campo]]
+            const elemento = this.elementos[campo]
     
             if (!elemento) {
-                throw new Error(`Campo ${campo} não encontrado nos elementos.`);
+                throw new Error(`Campo ${campo} não encontrado nos elementos.`)
             }
     
             acoes.forEach(acao => {
                 if (acao === 'habilitar' || acao === 'desabilitar') {
                     cy.get(elemento.seletorHabilitar).then($el => {
-                        const estadoAtual = $el.prop('checked');
-                        const estadoDesejado = acao === 'habilitar';
+                        const estadoAtual = $el.prop('checked')
+                        const estadoDesejado = acao === 'habilitar'
     
                         if (estadoAtual !== estadoDesejado) {
-                            cy.wrap($el).click({ force: true });
-                            cy.wait(250); // Aguarda um pouco para garantir que a ação seja processada
+                            cy.wrap($el).click({ force: true })
+                            cy.wait(250)
                         }
-                    });
+                    })
                 } else if (acao === 'obrigatório' || acao === 'não obrigatório') {
                     cy.get(elemento.seletorObrigatorio).then($el => {
-                        const estadoAtual = $el.prop('checked');
-                        const estadoDesejado = acao === 'obrigatório';
+                        const estadoAtual = $el.prop('checked')
+                        const estadoDesejado = acao === 'obrigatório'
     
                         if (estadoAtual !== estadoDesejado) {
-                            cy.wrap($el).click({ force: true });
-                            cy.wait(250); // Aguarda um pouco para garantir que a ação seja processada
+                            cy.wrap($el).click({ force: true })
+                            cy.wait(250)
                         }
-                    });
+                    })
                 } else {
-                    throw new Error(`Ação ${acao} não reconhecida para o campo ${campo}.`);
+                    throw new Error(`Ação ${acao} não reconhecida para o campo ${campo}.`)
                 }
-            });
-        });
+            })
+        })
     }
 
     salvar() {

--- a/cypress/support/pageObjects/formUsuarios.js
+++ b/cypress/support/pageObjects/formUsuarios.js
@@ -22,11 +22,11 @@ class formUsuarios {
         },
         telPessoal: {
             seletor: '#professional_phone1',
-            tipo: 'input'
+            tipo: 'input-fone'
         },
         celular: {
             seletor: '#professional_cell_phone',
-            tipo: 'input'
+            tipo: 'input-fone'
         },
         cep: {
             seletor: '#professional_zip_code',
@@ -70,7 +70,7 @@ class formUsuarios {
         },
         nrColaboradores: {
             seletor: '#professional_number_of_employees',
-            tipo: 'select'
+            tipo: 'input'
         },
         site: {
             seletor: '#professional_site',
@@ -78,7 +78,7 @@ class formUsuarios {
         },
         telComercial: {
             seletor: '#professional_phone2',
-            tipo: 'input'
+            tipo: 'input-fone'
         },
         cargo: {
             seletor: '#professional_role',
@@ -188,7 +188,7 @@ class formUsuarios {
 
 		let valorFinal = valor !== undefined ? valor : valorDefault
 
-		if (opcoes.limpar && tipo === 'input') {
+		if (opcoes.limpar && ( tipo === 'input' || tipo === 'input-fone')) {
 			cy.get(seletor)
 				.clear()
 			if (valorFinal === '') {
@@ -216,6 +216,7 @@ class formUsuarios {
                         .type(valorFinal, {delay: 200})
                     break
                 case 'input':
+                case 'input-fone':
                     cy.get(seletor)
                         .type(valorFinal)
                     break
@@ -301,7 +302,21 @@ class formUsuarios {
                         )
                     })
                 break
-            case 'checkbox':
+            case 'input-fone':
+                cy.get(seletor)
+                    .invoke('val')
+                    .then((telefoneSalvo) => {
+                        // Remove caracteres não numéricos do telefone
+                        const telefoneEsperado = valorFinal.replace(/\D/g, '')
+                        const telefoneEncontrado = telefoneSalvo.replace(/\D/g, '')
+            
+                        // Verifica se ambos os telefones têm a mesma quantidade de dígitos
+                        expect(telefoneEncontrado.length, 'Quantidade de dígitos').to.equal(telefoneEsperado.length);
+            
+                        // Verifica se os telefones são iguais
+                        expect(telefoneEncontrado, 'Telefone encontrado').to.equal(telefoneEsperado);
+                    });
+                break;            case 'checkbox':
             case 'checkbox2':
 				cy.get(seletor)
 					.should(valor ? 'be.checked' : 'not.be.checked')

--- a/cypress/support/utilsHelper.js
+++ b/cypress/support/utilsHelper.js
@@ -1,3 +1,5 @@
+import { faker } from '@faker-js/faker'
+
 /** DOCUMENTAÇÃO
  * @name gerarData
  * 
@@ -133,4 +135,35 @@ export function gerarTelefone(tipo) {
     } else {
     throw new Error(`Tipo de telefone inválido: ${tipo}. Utilize 'celular' ou 'fixo'`)
     }
+}
+
+export function gerarCEP(regiao = null) {
+    // Definindo as regiões postais e seus respectivos intervalos de CEP
+    const regioesPostais = {
+        0: '0', // Grande São Paulo
+        1: '1', // Interior de São Paulo
+        2: '2', // Rio de Janeiro e Espírito Santo
+        3: '3', // Minas Gerais
+        4: '4', // Bahia e Sergipe
+        5: '5', // Pernambuco, Alagoas, Paraíba e Rio Grande do Norte
+        6: '6', // Ceará, Piauí, Maranhão, Pará, Amazonas, Acre, Amapá e Roraima
+        7: '7', // Distrito Federal, Goiás, Tocantins, Mato Grosso, Mato Grosso do Sul e Rondônia
+        8: '8', // Paraná e Santa Catarina
+        9: '9'  // Rio Grande do Sul
+    }
+
+    // Se uma região específica for fornecida, use-a; caso contrário, escolha uma aleatória
+    const regiaoEscolhida = regiao !== null ? regiao : faker.helpers.arrayElement(Object.keys(regioesPostais))
+
+    // Gerando os outros dígitos do CEP
+    const subRegiao = faker.number.int({ min: 0, max: 9 })
+    const setor = faker.number.int({ min: 0, max: 9 })
+    const subSetor = faker.number.int({ min: 0, max: 9 })
+    const divisorSubSetor = faker.number.int({ min: 0, max: 9 })
+    const identificadorDistribuicao = faker.number.int({ min: 0, max: 999 }).toString().padStart(3, '0')
+    
+    // Montando o CEP completo
+    const cep = `${regioesPostais[regiaoEscolhida]}${subRegiao}${setor}${subSetor}${divisorSubSetor}-${identificadorDistribuicao}`
+
+    return cep
 }

--- a/cypress/support/utilsHelper.js
+++ b/cypress/support/utilsHelper.js
@@ -167,3 +167,24 @@ export function gerarCEP(regiao = null) {
 
     return cep
 }
+
+export function verificarPerfilENomeUsuario() {
+    return cy.get('body').then(($body) => {
+      const nomeUsuario = $body.find('.name').text().trim()
+      const perfilAtual = $body.find('#btn-profile').text().trim()
+  
+      if (!nomeUsuario && !perfilAtual) {
+        return { acao: 'login' }
+      }
+  
+      if (nomeUsuario !== Cypress.env('username')) {
+        return { acao: 'logout' }
+      }
+  
+      if (nomeUsuario === Cypress.env('username') && perfilAtual !== 'Administrador') {
+        return { acao: 'alterarPerfil' }
+      }
+  
+      return { acao: 'N/A' }
+    })
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -41,7 +41,7 @@
 
 "@faker-js/faker@^8.4.1":
   version "8.4.1"
-  resolved "https://registry.npmjs.org/@faker-js/faker/-/faker-8.4.1.tgz"
+  resolved "https://registry.yarnpkg.com/@faker-js/faker/-/faker-8.4.1.tgz#5d5e8aee8fce48f5e189bf730ebd1f758f491451"
   integrity sha512-XQ3cU+Q8Uqmrbf2e0cIC/QN43sTBSC8KF12u29Mb47tWrt2hAgBXSgpZMj4Ao8Uk0iJcU99QsOCaIL8934obCg==
 
 "@types/cypress@^1.1.3":


### PR DESCRIPTION
#### 🤖 FUNCIONALIDADE
Registre-se

#### 🎯 AUTOMAÇÃO
Implementação de testes de CRUD de um usuário que é criado no ambiente via 'Registre-se' da página de login do link personalizado. Após este usuário ser criado, são validados os dados no cadastro do usuário, atualizados e o usuário é excluído.

Para esta implementação foi necessário implementar também a configuração dos campos customizados via SuperAdmin, que não estava previsto inicialmente. Para isso foi criada a PageObject com o mapeamento e funções e também comando para configuração geral de todos os campos.

#### :heavy_check_mark: ATIVIDADE
[CRUD - Registre-se](https://app.artia.com/a/4874953/f/5152797/activities/27153523)
[SuperAdmin - Campos customizados](https://app.artia.com/a/4874953/f/5152797/activities/27862112)

#### :hammer_and_wrench: Tipo de mudança
 - [X] Novos cenários (mudança que adiciona novos cenários automatizados)
 - [ ] Correção de quebras (alteração que corrige um problema)
 - [ ] Atualização de cenários (quando alterada a regra de negócio)
 - [ ] Refatoração (Mudança no código que mantém o funcionamento como esperado)
 - [ ] Esta mudança requer uma atualização dos casos de testes no TestLink

#### :checkered_flag: CHECKLIST
- [X] Meu código segue as diretrizes de estilo deste projeto
- [X] Eu fiz uma autoavaliação do meu próprio código
- [X] Eu validei meus testes confirmando que minha implementação é eficaz ou que ela funciona como esperado
