### PR TITLE
Remoção 'const formulario' inclusão 'new' no export da PageObject

### DIFF
--- a/cypress/e2e/catalogo.cy.js
+++ b/cypress/e2e/catalogo.cy.js
@@ -6,8 +6,6 @@ import { gerarData } from '../support/utilsHelper'
 import formConteudos from "../support/pageObjects/formConteudos"
 
 describe('catálogo', () => {
-	const formulario = new formConteudos()
-
 	let nome, tipoConteudo, categorias, novasCategorias, delCategorias
 
 	// Campos e dados default do formulário de catálogo

--- a/cypress/e2e/catalogoCriarCurso.cy.js
+++ b/cypress/e2e/catalogoCriarCurso.cy.js
@@ -5,9 +5,7 @@ import { getAuthToken } from '../support/authHelper'
 import { converterDataEHoraParaISO } from '../support/utilsHelper'
 import formConteudos from "../support/pageObjects/formConteudos"
 
-describe('criar curso via catálogo', () => {
-	const formulario = new formConteudos()
-	
+describe('criar curso via catálogo', () => {	
 	let nome, tipoConteudo, categorias, novasCategorias, delCategorias
 
 	// Campos e dados default do formulário de criar curso via catálogo
@@ -142,7 +140,7 @@ describe('criar curso via catálogo', () => {
 		cy.loginTwygoAutomacao()
 		cy.alterarPerfil('administrador')
 		cy.acessarPgCatalogo()	
-		formulario.criarCursoViaCatalogo(catalogo.nome)
+		formConteudos.criarCursoViaCatalogo(catalogo.nome)
 		cy.salvarConteudo(catalogo.nome, tipoConteudo)
 
 		// READ
@@ -270,7 +268,7 @@ describe('criar curso via catálogo', () => {
 		cy.loginTwygoAutomacao()
 		cy.alterarPerfil('administrador')
 		cy.acessarPgCatalogo()	
-		formulario.criarCursoViaCatalogo(catalogo.nome)
+		formConteudos.criarCursoViaCatalogo(catalogo.nome)
 		cy.salvarConteudo(catalogo.nome, tipoConteudo)
 
 		// READ
@@ -386,7 +384,7 @@ describe('criar curso via catálogo', () => {
 		cy.loginTwygoAutomacao()
 		cy.alterarPerfil('administrador')
 		cy.acessarPgCatalogo()	
-		formulario.criarCursoViaCatalogo(catalogo.nome)
+		formConteudos.criarCursoViaCatalogo(catalogo.nome)
 		cy.salvarConteudo(catalogo.nome, tipoConteudo)
 
 		// READ
@@ -477,7 +475,7 @@ describe('criar curso via catálogo', () => {
 		cy.loginTwygoAutomacao()
 		cy.alterarPerfil('administrador')
 		cy.acessarPgCatalogo()	
-		formulario.criarCursoViaCatalogo(catalogo.nome)
+		formConteudos.criarCursoViaCatalogo(catalogo.nome)
 		cy.salvarConteudo(catalogo.nome, tipoConteudo)
 
 		// READ
@@ -570,7 +568,7 @@ describe('criar curso via catálogo', () => {
 		cy.preencherDadosConteudo(conteudoEdit1, { limpar: true })
 		cy.salvarConteudo(catalogo.nome, 'catalogo')
 
-		formulario.criarCursoViaCatalogo(catalogo.nome)
+		formConteudos.criarCursoViaCatalogo(catalogo.nome)
 		// Preencher com novos dados do curso
 		const novoNome = fakerPT_BR.commerce.productName()
 		categorias = [`Cat1-${fakerPT_BR.hacker.noun()}`, `Cat2-${fakerPT_BR.hacker.noun()}`]
@@ -709,7 +707,7 @@ describe('criar curso via catálogo', () => {
 		cy.salvarConteudo(catalogo.nome, 'catalogo')
 
 		// Clicar em "Criar curso" do catálogo
-		formulario.criarCursoViaCatalogo(catalogo.nome)
+		formConteudos.criarCursoViaCatalogo(catalogo.nome)
 
 		// Preencher com novos dados do curso
 		let novoNome = fakerPT_BR.commerce.productName()
@@ -943,7 +941,7 @@ describe('criar curso via catálogo', () => {
 		cy.preencherDadosConteudo(conteudo, { limpar: true })
 		cy.salvarConteudo(conteudo.nome, 'catalogo')
 
-		formulario.criarCursoViaCatalogo(conteudo.nome)
+		formConteudos.criarCursoViaCatalogo(conteudo.nome)
 		cy.salvarConteudo(conteudo.nome, tipoConteudo)
 
 		// READ

--- a/cypress/e2e/perguntasPesquisa.cy.js
+++ b/cypress/e2e/perguntasPesquisa.cy.js
@@ -4,9 +4,6 @@ import formQuestionarios from '../support/pageObjects/formQuestionarios'
 import formPerguntas from '../support/pageObjects/formPerguntas'
 
 describe('Perguntas', () => {
-    const formulario = new formPerguntas()
-    const formQuest = new formQuestionarios()
-
     let titulo, novoTitulo, tipoPergunta, nomeQuestionario, listaQuestionarios, categorias1, categorias2
 
     before(() => {
@@ -46,7 +43,7 @@ describe('Perguntas', () => {
         cy.excluirQuestionarios(null, listaQuestionarios)
 
         // Criar questionário
-        formQuest.addQuestionario()
+        formQuestionarios.addQuestionario()
         cy.preencherDadosQuestionario(dadosQuest)
         cy.salvarQuestionario(dadosQuest.nome)
 
@@ -77,7 +74,7 @@ describe('Perguntas', () => {
         cy.log('## CREATE ##')
         
         cy.acessarPerguntasQuestionario(nomeQuestionario)
-        formulario.addPergunta()
+        formPerguntas.addPergunta()
 
         // Preencher os campos da pergunta
         cy.preencherDadosPergunta(dados, { limpar: true })
@@ -137,7 +134,7 @@ describe('Perguntas', () => {
         cy.log('## CREATE ##')
         
         cy.acessarPerguntasQuestionario(nomeQuestionario)
-        formulario.addPergunta()
+        formPerguntas.addPergunta()
 
         // Preencher os campos da pergunta
         cy.preencherDadosPergunta(dados, { limpar: true })
@@ -197,7 +194,7 @@ describe('Perguntas', () => {
         cy.log('## CREATE ##')
         
         cy.acessarPerguntasQuestionario(nomeQuestionario)
-        formulario.addPergunta()
+        formPerguntas.addPergunta()
 
         // Preencher os campos da pergunta
         cy.preencherDadosPergunta(dados, { limpar: true })
@@ -257,7 +254,7 @@ describe('Perguntas', () => {
         cy.log('## CREATE ##')
         
         cy.acessarPerguntasQuestionario(nomeQuestionario)
-        formulario.addPergunta()
+        formPerguntas.addPergunta()
 
         // Preencher os campos da pergunta
         cy.preencherDadosPergunta(dados, { limpar: true })
@@ -317,7 +314,7 @@ describe('Perguntas', () => {
         cy.log('## CREATE ##')
         
         cy.acessarPerguntasQuestionario(nomeQuestionario)
-        formulario.addPergunta()
+        formPerguntas.addPergunta()
 
         // Preencher os campos da pergunta
         cy.preencherDadosPergunta(dados, { limpar: true })
@@ -377,7 +374,7 @@ describe('Perguntas', () => {
         cy.log('## CREATE ##')
         
         cy.acessarPerguntasQuestionario(nomeQuestionario)
-        formulario.addPergunta()
+        formPerguntas.addPergunta()
 
         // Preencher os campos da pergunta
         cy.preencherDadosPergunta(dados, { limpar: true })
@@ -407,7 +404,7 @@ describe('Perguntas', () => {
         }
 
         cy.expandirPergunta(dados.descricao)
-        formulario.addResposta()
+        formPerguntas.addResposta()
         cy.preencherDadosPergunta(dadosUpdate, { limpar: true })
         cy.salvarEdicaoPergunta(dados.descricao, dadosUpdate.descricao)
 
@@ -441,7 +438,7 @@ describe('Perguntas', () => {
         cy.log('## CREATE ##')
         
         cy.acessarPerguntasQuestionario(nomeQuestionario)
-        formulario.addPergunta()
+        formPerguntas.addPergunta()
 
         // Preencher os campos da pergunta
         cy.preencherDadosPergunta(dados, { limpar: true })
@@ -503,7 +500,7 @@ describe('Perguntas', () => {
         cy.log('## CREATE ##')
         
         cy.acessarPerguntasQuestionario(nomeQuestionario)
-        formulario.addPergunta()
+        formPerguntas.addPergunta()
 
         // Preencher os campos da pergunta
         cy.preencherDadosPergunta(dados, { limpar: true })
@@ -531,7 +528,7 @@ describe('Perguntas', () => {
         }
 
         cy.expandirPergunta(dados.descricao)
-        formulario.addResposta()
+        formPerguntas.addResposta()
         cy.preencherDadosPergunta(dadosUpdate, { limpar: true })
         cy.salvarEdicaoPergunta(dados.descricao, dadosUpdate.descricao)
 
@@ -565,7 +562,7 @@ describe('Perguntas', () => {
         cy.log('## CREATE ##')
         
         cy.acessarPerguntasQuestionario(nomeQuestionario)
-        formulario.addPergunta()
+        formPerguntas.addPergunta()
 
         // Preencher os campos da pergunta
         cy.preencherDadosPergunta(dados, { limpar: true })
@@ -623,7 +620,7 @@ describe('Perguntas', () => {
         cy.log('## CREATE ##')
         
         cy.acessarPerguntasQuestionario(nomeQuestionario)
-        formulario.addPergunta()
+        formPerguntas.addPergunta()
 
         // Preencher os campos da pergunta
         cy.preencherDadosPergunta(dados, { limpar: true })

--- a/cypress/e2e/perguntasProva.cy.js
+++ b/cypress/e2e/perguntasProva.cy.js
@@ -4,9 +4,6 @@ import formQuestionarios from '../support/pageObjects/formQuestionarios'
 import formPerguntas from '../support/pageObjects/formPerguntas'
 
 describe('Perguntas', () => {
-    const formulario = new formPerguntas()
-    const formQuest = new formQuestionarios()
-
     let titulo, novoTitulo, tipoPergunta, nomeQuestionario, listaQuestionarios, categorias1, categorias2
 
     before(() => {
@@ -45,7 +42,7 @@ describe('Perguntas', () => {
         cy.excluirQuestionarios(null, listaQuestionarios)
 
         // Criar questionário
-        formQuest.addQuestionario()
+        formQuestionarios.addQuestionario()
         cy.preencherDadosQuestionario(dadosQuest)
         cy.salvarQuestionario(dadosQuest.nome)
 
@@ -76,7 +73,7 @@ describe('Perguntas', () => {
         cy.log('## CREATE ##')
         
         cy.acessarPerguntasQuestionario(nomeQuestionario)
-        formulario.addPergunta()
+        formPerguntas.addPergunta()
 
         // Preencher os campos da pergunta
         cy.preencherDadosPergunta(dados, { limpar: true })
@@ -136,7 +133,7 @@ describe('Perguntas', () => {
         cy.log('## CREATE ##')
         
         cy.acessarPerguntasQuestionario(nomeQuestionario)
-        formulario.addPergunta()
+        formPerguntas.addPergunta()
 
         // Preencher os campos da pergunta
         cy.preencherDadosPergunta(dados, { limpar: true })
@@ -196,7 +193,7 @@ describe('Perguntas', () => {
         cy.log('## CREATE ##')
         
         cy.acessarPerguntasQuestionario(nomeQuestionario)
-        formulario.addPergunta()
+        formPerguntas.addPergunta()
 
         // Preencher os campos da pergunta
         cy.preencherDadosPergunta(dados, { limpar: true })
@@ -258,7 +255,7 @@ describe('Perguntas', () => {
         cy.log('## CREATE ##')
         
         cy.acessarPerguntasQuestionario(nomeQuestionario)
-        formulario.addPergunta()
+        formPerguntas.addPergunta()
 
         // Preencher os campos da pergunta
         cy.preencherDadosPergunta(dados, { limpar: true })
@@ -321,7 +318,7 @@ describe('Perguntas', () => {
         cy.log('## CREATE ##')
         
         cy.acessarPerguntasQuestionario(nomeQuestionario)
-        formulario.addPergunta()
+        formPerguntas.addPergunta()
 
         // Preencher os campos da pergunta
         cy.preencherDadosPergunta(dados, { limpar: true })
@@ -382,7 +379,7 @@ describe('Perguntas', () => {
         cy.log('## CREATE ##')
         
         cy.acessarPerguntasQuestionario(nomeQuestionario)
-        formulario.addPergunta()
+        formPerguntas.addPergunta()
 
         // Preencher os campos da pergunta
         cy.preencherDadosPergunta(dados, { limpar: true })
@@ -415,7 +412,7 @@ describe('Perguntas', () => {
         }
 
         cy.expandirPergunta(dados.descricao)
-        formulario.addResposta()
+        formPerguntas.addResposta()
         cy.preencherDadosPergunta(dadosUpdate, { limpar: true })
         cy.salvarEdicaoPergunta(dados.descricao, dadosUpdate.descricao)
 
@@ -449,7 +446,7 @@ describe('Perguntas', () => {
         cy.log('## CREATE ##')
         
         cy.acessarPerguntasQuestionario(nomeQuestionario)
-        formulario.addPergunta()
+        formPerguntas.addPergunta()
 
         // Preencher os campos da pergunta
         cy.preencherDadosPergunta(dados, { limpar: true })
@@ -511,7 +508,7 @@ describe('Perguntas', () => {
         cy.log('## CREATE ##')
         
         cy.acessarPerguntasQuestionario(nomeQuestionario)
-        formulario.addPergunta()
+        formPerguntas.addPergunta()
 
         // Preencher os campos da pergunta
         cy.preencherDadosPergunta(dados, { limpar: true })
@@ -542,7 +539,7 @@ describe('Perguntas', () => {
         }
 
         cy.expandirPergunta(dados.descricao)
-        formulario.addResposta()
+        formPerguntas.addResposta()
         cy.preencherDadosPergunta(dadosUpdate, { limpar: true })
         cy.salvarEdicaoPergunta(dados.descricao, dadosUpdate.descricao)
 
@@ -578,7 +575,7 @@ describe('Perguntas', () => {
         cy.log('## CREATE ##')
         
         cy.acessarPerguntasQuestionario(nomeQuestionario)
-        formulario.addPergunta()
+        formPerguntas.addPergunta()
 
         // Preencher os campos da pergunta
         cy.preencherDadosPergunta(dados, { limpar: true })
@@ -637,7 +634,7 @@ describe('Perguntas', () => {
         cy.log('## CREATE ##')
         
         cy.acessarPerguntasQuestionario(nomeQuestionario)
-        formulario.addPergunta()
+        formPerguntas.addPergunta()
 
         // Preencher os campos da pergunta
         cy.preencherDadosPergunta(dados, { limpar: true })

--- a/cypress/e2e/questionario.cy.js
+++ b/cypress/e2e/questionario.cy.js
@@ -3,8 +3,6 @@ import { fakerPT_BR } from '@faker-js/faker'
 import formQuestionarios from '../support/pageObjects/formQuestionarios'
 
 describe('Questionário', () => {
-    const formulario = new formQuestionarios()
-
     let nomeQuestionario, nomeCategoria1, nomeCategoria2, addCategoria1, addCategoria2, categoriasAtualizadas, listaQuestionarios
     
     // Campos e dados default do formulário de questionário
@@ -75,7 +73,7 @@ describe('Questionário', () => {
         // CREATE
         cy.log('## CREATE ##')
 
-        formulario.addQuestionario()
+        formQuestionarios.addQuestionario()
         cy.preencherDadosQuestionario(dados, { limpar: true })
         cy.salvarQuestionario(dados.nome)
 
@@ -112,7 +110,7 @@ describe('Questionário', () => {
         // DELETE
         cy.log('## DELETE ##')
 
-        formulario.voltarQuestionario()
+        formQuestionarios.voltarQuestionario()
         cy.excluirQuestionarios(dadosUpdate.nome)
     })
 
@@ -133,7 +131,7 @@ describe('Questionário', () => {
         // CREATE
         cy.log('## CREATE ##')
 
-        formulario.addQuestionario()
+        formQuestionarios.addQuestionario()
         cy.preencherDadosQuestionario(dados, { limpar: true })
         cy.salvarQuestionario(dados.nome)
 
@@ -170,7 +168,7 @@ describe('Questionário', () => {
         // DELETE
         cy.log('## DELETE ##')
 
-        formulario.voltarQuestionario()
+        formQuestionarios.voltarQuestionario()
         cy.excluirQuestionarios(dadosUpdate.nome)
     })
 
@@ -191,7 +189,7 @@ describe('Questionário', () => {
         // CREATE
         cy.log('## CREATE ##')
 
-        formulario.addQuestionario()
+        formQuestionarios.addQuestionario()
         cy.preencherDadosQuestionario(dados, { limpar: true })
         cy.salvarQuestionario(dados.nome)
 
@@ -228,7 +226,7 @@ describe('Questionário', () => {
         // DELETE
         cy.log('## DELETE ##')
 
-        formulario.voltarQuestionario()
+        formQuestionarios.voltarQuestionario()
         cy.excluirQuestionarios(dadosUpdate.nome)
     })
 
@@ -249,7 +247,7 @@ describe('Questionário', () => {
         // CREATE
         cy.log('## CREATE ##')
 
-        formulario.addQuestionario()
+        formQuestionarios.addQuestionario()
         cy.preencherDadosQuestionario(dados, { limpar: true })
         cy.salvarQuestionario(dados.nome)
 
@@ -286,7 +284,7 @@ describe('Questionário', () => {
         // DELETE
         cy.log('## DELETE ##')
 
-        formulario.voltarQuestionario()
+        formQuestionarios.voltarQuestionario()
         cy.excluirQuestionarios(dadosUpdate.nome)
     })
 
@@ -307,7 +305,7 @@ describe('Questionário', () => {
         // CREATE
         cy.log('## CREATE ##')
 
-        formulario.addQuestionario()
+        formQuestionarios.addQuestionario()
         cy.preencherDadosQuestionario(dados, { limpar: true })
         cy.salvarQuestionario(dados.nome)
 
@@ -361,7 +359,7 @@ describe('Questionário', () => {
         // DELETE
         cy.log('## DELETE ##')
 
-        formulario.voltarQuestionario()
+        formQuestionarios.voltarQuestionario()
         cy.excluirQuestionarios(dadosUpdate.nome)
     })
 
@@ -382,7 +380,7 @@ describe('Questionário', () => {
         // CREATE
         cy.log('## CREATE ##')
 
-        formulario.addQuestionario()
+        formQuestionarios.addQuestionario()
         cy.preencherDadosQuestionario(dados, { limpar: true })
         cy.salvarQuestionario(dados.nome)
 
@@ -436,7 +434,7 @@ describe('Questionário', () => {
         // DELETE
         cy.log('## DELETE ##')
 
-        formulario.voltarQuestionario()
+        formQuestionarios.voltarQuestionario()
         cy.excluirQuestionarios(dadosUpdate.nome)
     })
 
@@ -449,7 +447,7 @@ describe('Questionário', () => {
         // CREATE
         cy.log('## CREATE ##')
 
-        formulario.addQuestionario()
+        formQuestionarios.addQuestionario()
         cy.preencherDadosQuestionario(dados, { limpar: true })
         cy.salvarQuestionario(dados.nome)
 
@@ -488,7 +486,7 @@ describe('Questionário', () => {
         // DELETE
         cy.log('## DELETE ##')
 
-        formulario.voltarQuestionario()
+        formQuestionarios.voltarQuestionario()
         cy.excluirQuestionarios(dadosUpdate.nome)
     })
 })

--- a/cypress/e2e/trial.cy.js
+++ b/cypress/e2e/trial.cy.js
@@ -2,8 +2,6 @@
 import { faker, fakerPT_BR } from '@faker-js/faker'
 import formTrial from '../support/pageObjects/formTrial'
 
-const formulario = new formTrial()
-
 describe('Criar organização "Trial"', () => {
     let senha
 
@@ -91,7 +89,7 @@ describe('Criar organização "Trial"', () => {
 
         // Voltar ao primeiro step para validar que os dados não foram perdidos
         for (let i = 0; i < 4; i++) {
-            formulario.voltarStep()
+            formTrial.voltarStep()
         }
 
         // Valida os dados preenchidos aba "Seus dados"
@@ -126,7 +124,7 @@ describe('Criar organização "Trial"', () => {
 
         // Voltar ao primeiro step para alterar os dados
         for (let i = 0; i < 4; i++) {
-            formulario.voltarStep()
+            formTrial.voltarStep()
         }
 
         // Massa de dados
@@ -184,7 +182,7 @@ describe('Criar organização "Trial"', () => {
 
         // Voltar ao primeiro step para validar que os dados não foram perdidos
         for (let i = 0; i < 4; i++) {
-            formulario.voltarStep()
+            formTrial.voltarStep()
         }
 
         // Valida os dados preenchidos aba "Seus dados"
@@ -287,7 +285,7 @@ describe('Criar organização "Trial"', () => {
 
         // Voltar ao primeiro step para validar que os dados não foram perdidos
         for (let i = 0; i < 4; i++) {
-            formulario.voltarStep()
+            formTrial.voltarStep()
         }
 
         // Valida os dados preenchidos aba "Seus dados"
@@ -322,7 +320,7 @@ describe('Criar organização "Trial"', () => {
 
         // Voltar ao primeiro step para alterar os dados
         for (let i = 0; i < 4; i++) {
-            formulario.voltarStep()
+            formTrial.voltarStep()
         }
 
         // Massa de dados
@@ -380,7 +378,7 @@ describe('Criar organização "Trial"', () => {
 
         // Voltar ao primeiro step para validar que os dados não foram perdidos
         for (let i = 0; i < 4; i++) {
-            formulario.voltarStep()
+            formTrial.voltarStep()
         }
 
         // Valida os dados preenchidos aba "Seus dados"
@@ -483,7 +481,7 @@ describe('Criar organização "Trial"', () => {
 
         // Voltar ao primeiro step para validar que os dados não foram perdidos
         for (let i = 0; i < 4; i++) {
-            formulario.voltarStep()
+            formTrial.voltarStep()
         }
 
         // Valida os dados preenchidos aba "Seus dados"
@@ -518,7 +516,7 @@ describe('Criar organização "Trial"', () => {
 
         // Voltar ao primeiro step para alterar os dados
         for (let i = 0; i < 4; i++) {
-            formulario.voltarStep()
+            formTrial.voltarStep()
         }
 
         // Massa de dados
@@ -576,7 +574,7 @@ describe('Criar organização "Trial"', () => {
 
         // Voltar ao primeiro step para validar que os dados não foram perdidos
         for (let i = 0; i < 4; i++) {
-            formulario.voltarStep()
+            formTrial.voltarStep()
         }
 
         // Valida os dados preenchidos aba "Seus dados"
@@ -679,7 +677,7 @@ describe('Criar organização "Trial"', () => {
 
         // Voltar ao primeiro step para validar que os dados não foram perdidos
         for (let i = 0; i < 4; i++) {
-            formulario.voltarStep()
+            formTrial.voltarStep()
         }
 
         // Valida os dados preenchidos aba "Seus dados"
@@ -714,7 +712,7 @@ describe('Criar organização "Trial"', () => {
 
         // Voltar ao primeiro step para alterar os dados
         for (let i = 0; i < 4; i++) {
-            formulario.voltarStep()
+            formTrial.voltarStep()
         }
 
         // Massa de dados
@@ -772,7 +770,7 @@ describe('Criar organização "Trial"', () => {
 
         // Voltar ao primeiro step para validar que os dados não foram perdidos
         for (let i = 0; i < 4; i++) {
-            formulario.voltarStep()
+            formTrial.voltarStep()
         }
 
         // Valida os dados preenchidos aba "Seus dados"
@@ -875,7 +873,7 @@ describe('Criar organização "Trial"', () => {
 
         // Voltar ao primeiro step para validar que os dados não foram perdidos
         for (let i = 0; i < 4; i++) {
-            formulario.voltarStep()
+            formTrial.voltarStep()
         }
 
         // Valida os dados preenchidos aba "Seus dados"
@@ -910,7 +908,7 @@ describe('Criar organização "Trial"', () => {
 
         // Voltar ao primeiro step para alterar os dados
         for (let i = 0; i < 4; i++) {
-            formulario.voltarStep()
+            formTrial.voltarStep()
         }
 
         // Massa de dados
@@ -968,7 +966,7 @@ describe('Criar organização "Trial"', () => {
 
         // Voltar ao primeiro step para validar que os dados não foram perdidos
         for (let i = 0; i < 4; i++) {
-            formulario.voltarStep()
+            formTrial.voltarStep()
         }
 
         // Valida os dados preenchidos aba "Seus dados"

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -192,7 +192,6 @@ Cypress.Commands.add('acessarPgQuestionarios', function() {
 })
 
 Cypress.Commands.add('acessarPgConfigOrganizacao', function(aba) {
-  const formulario = new formConfigOrganizacao()
   const labels = Cypress.env('labels')
   const { breadcrumb } = labels.configOrganizacao
   
@@ -205,22 +204,22 @@ Cypress.Commands.add('acessarPgConfigOrganizacao', function(aba) {
   if (aba) {
     switch (aba) {
       case 'dados':
-        formulario.abaDados()
+        formConfigOrganizacao.abaDados()
         break
       case 'customizacoes':
-        formulario.abaCustomizacoes()
+        formConfigOrganizacao.abaCustomizacoes()
         break
       case 'certificado':
-        formulario.abaCertificado()
+        formConfigOrganizacao.abaCertificado()
         break
       case 'integracoes':
-        formulario.abaIntegracoes()
+        formConfigOrganizacao.abaIntegracoes()
         break
       case 'termos':
-        formulario.abaTermos()
+        formConfigOrganizacao.abaTermos()
         break
       case 'urlWebhooks':
-        formulario.abaUrlWebhooks()
+        formConfigOrganizacao.abaUrlWebhooks()
         break
       default:
         throw new Error(`Aba inválida: ${aba}. Utilize 'dados', 'customizacoes', 'certificado', 'integracoes', 'termos' ou 'urlWebhooks'`)
@@ -347,11 +346,9 @@ Cypress.Commands.add('excluirCursoViaApi', function() {
 })
 
 Cypress.Commands.add('preencherDadosConteudo', (conteudo, opcoes = { limpar: false }) => {
-  const formulario = new formConteudos()
-  
   Object.keys(conteudo).forEach(nomeCampo => {
       const valor = conteudo[nomeCampo]
-      formulario.preencherCampo(nomeCampo, valor, opcoes)
+      formConteudos.preencherCampo(nomeCampo, valor, opcoes)
   })
 }) 
 
@@ -364,11 +361,9 @@ Cypress.Commands.add('validarDadosConteudo', (conteudo, categoria) => {
     throw new Error('O parâmetro "categoria" é obrigatório.')
   }
 
-  const formulario = new formConteudos()
-
   Object.keys(conteudo).forEach(nomeCampo => {
     const valor = conteudo[nomeCampo] !== undefined ? conteudo[nomeCampo] : valorDefault
-    formulario.validarCampo(nomeCampo, valor, categoria)
+    formConteudos.validarCampo(nomeCampo, valor, categoria)
   })
 })
 
@@ -758,20 +753,16 @@ Cypress.Commands.add('editarAtividade', (nomeConteudo, nomeAtividade) => {
 })
 
 Cypress.Commands.add('preencherDadosAtividade', (dados, opcoes = { limpar: false }) => {
-  const formulario = new formAtividades()
-  
   Object.keys(dados).forEach(nomeCampo => {
       const valor = dados[nomeCampo]
-      formulario.preencherCampo(nomeCampo, valor, opcoes)
+      formAtividades.preencherCampo(nomeCampo, valor, opcoes)
   })
 })
 
 Cypress.Commands.add('validarDadosAtividade', (dados) => {
-  const formulario = new formAtividades()
-
   Object.keys(dados).forEach(nomeCampo => {
     const valor = dados[nomeCampo] !== undefined ? dados[nomeCampo] : valorDefault
-    formulario.validarCampo(nomeCampo, valor)
+    formAtividades.validarCampo(nomeCampo, valor)
   })
 })
 
@@ -851,20 +842,16 @@ Cypress.Commands.add("criarCursoViaApi", (body, attempt = 1) => {
 })
 
 Cypress.Commands.add('preencherDadosBiblioteca', (conteudo, opcoes = { limpar: false }) => {
-  const formulario = new formBiblioteca()
-  
   Object.keys(conteudo).forEach(nomeCampo => {
       const valor = conteudo[nomeCampo]
-      formulario.preencherCampo(nomeCampo, valor, opcoes)
+      formBiblioteca.preencherCampo(nomeCampo, valor, opcoes)
   })
 }) 
 
 Cypress.Commands.add('validarDadosBiblioteca', (conteudo) => {
-  const formulario = new formBiblioteca()
-
   Object.keys(conteudo).forEach(nomeCampo => {
     const valor = conteudo[nomeCampo] !== undefined ? conteudo[nomeCampo] : valorDefault
-    formulario.validarCampo(nomeCampo, valor)
+    formBiblioteca.validarCampo(nomeCampo, valor)
   })
 })
 
@@ -943,20 +930,16 @@ Cypress.Commands.add('criarTrilhaDefault', (nomeConteudo) => {
 })
 
 Cypress.Commands.add('preencherDadosQuestionario', (dados, opcoes = { limpar: false }) => {
-  const formulario = new formQuestionarios()
-  
   Object.keys(dados).forEach(nomeCampo => {
       const valor = dados[nomeCampo]
-      formulario.preencherCampo(nomeCampo, valor, opcoes)
+      formQuestionarios.preencherCampo(nomeCampo, valor, opcoes)
   })
 })
 
 Cypress.Commands.add('validarDadosQuestionario', (dados) => {
-  const formulario = new formQuestionarios()
-
   Object.keys(dados).forEach(nomeCampo => {
     const valor = dados[nomeCampo] !== undefined ? dados[nomeCampo] : valorDefault
-    formulario.validarCampo(nomeCampo, valor)
+    formQuestionarios.validarCampo(nomeCampo, valor)
   })
 })
 
@@ -988,9 +971,6 @@ Cypress.Commands.add('excluirQuestionarios', (nomeQuestionario, listaQuestionari
   // Acessa o arquivo de labels
   const labels = Cypress.env('labels')
 
-  // Inicializa formulário de questionários
-  const formulario = new formQuestionarios()
-
   // Função para excluir um questionário específico
   const excluirQuestionarioEspecifico = (nomeQuestionario) => {
     const { tituloModalExclusao, textoModalExclusao, msgSucessoExclusao } = labels.questionario
@@ -1000,7 +980,7 @@ Cypress.Commands.add('excluirQuestionarios', (nomeQuestionario, listaQuestionari
     // Clica em 'Excluir'
     cy.get(seletor)
       .wait(2000)
-      .find(formulario.elementos.btnExcluir.seletor, formulario.elementos.btnExcluir.title)
+      .find(formQuestionarios.elementos.btnExcluir.seletor, formQuestionarios.elementos.btnExcluir.title)
       .click({ force: true })
 
     // Valida o título do modal de exclusão
@@ -1018,7 +998,7 @@ Cypress.Commands.add('excluirQuestionarios', (nomeQuestionario, listaQuestionari
       })    
       
     // Confirma a exclusão
-    cy.contains(formulario.elementos.btnConfirmarExclusao.seletor, 'Confirmar')
+    cy.contains(formQuestionarios.elementos.btnConfirmarExclusao.seletor, 'Confirmar')
       .click({ force: true })
 
     // Valida a mensagem de sucesso da exclusão
@@ -1044,12 +1024,11 @@ Cypress.Commands.add('excluirQuestionarios', (nomeQuestionario, listaQuestionari
 })
 
 Cypress.Commands.add('salvarQuestionario', (nomeQuestionario) => {
-  const formulario = new formQuestionarios()
   const labels = Cypress.env('labels')
   const { msgSucesso } = labels.questionario
 
   // Salva o questionário
-  formulario.salvarQuestionario()
+  formQuestionarios.salvarQuestionario()
 
   // Confirma a mensagem de sucesso
   cy.contains('.flash.notice', msgSucesso)
@@ -1061,13 +1040,12 @@ Cypress.Commands.add('salvarQuestionario', (nomeQuestionario) => {
 })
 
 Cypress.Commands.add('editarQuestionario', (nomeQuestionario) => {
-  const formulario = new formQuestionarios()
   const labels = Cypress.env('labels')
   const { breadcrumb, tituloPgEdicao } = labels.questionario
 
   // Edita o questionário
   cy.get(`tr[name='${nomeQuestionario}']`)
-    .find(formulario.elementos.btnEditar.seletor, formulario.elementos.btnEditar.title)
+    .find(formQuestionarios.elementos.btnEditar.seletor, formQuestionarios.elementos.btnEditar.title)
     .click()
 
   // Validar se a página foi carregada corretamente
@@ -1079,14 +1057,12 @@ Cypress.Commands.add('editarQuestionario', (nomeQuestionario) => {
 })
 
 Cypress.Commands.add('criarQuestionarioDefault', (nomeQuestionario) => {
-  const formulario = new formQuestionarios()
-  
   const dados = {
     nome: nomeQuestionario
   }
 
   cy.acessarPgQuestionarios()
-  formulario.addQuestionario()
+  formQuestionarios.addQuestionario()
   cy.preencherDadosQuestionario(dados)
   cy.salvarQuestionario(dados.nome)
 })
@@ -1113,25 +1089,20 @@ Cypress.Commands.add('acessarPerguntasQuestionario', (nomeQuestionario) => {
 })
 
 Cypress.Commands.add('preencherDadosPergunta', (conteudo, opcoes = { limpar: false }) => {
-  const formulario = new formPerguntas()
-  
   Object.keys(conteudo).forEach(nomeCampo => {
       const valor = conteudo[nomeCampo]
-      formulario.preencherCampo(nomeCampo, valor, opcoes)
+      formPerguntas.preencherCampo(nomeCampo, valor, opcoes)
   })
 }) 
 
 Cypress.Commands.add('validarDadosPergunta', (conteudo) => {
-  const formulario = new formPerguntas()
-
   Object.keys(conteudo).forEach(nomeCampo => {
     const valor = conteudo[nomeCampo] !== undefined ? conteudo[nomeCampo] : valorDefault
-    formulario.validarCampo(nomeCampo, valor)
+    formPerguntas.validarCampo(nomeCampo, valor)
   })
 })
 
 Cypress.Commands.add('salvarPergunta', (descPergunta, index) => {
-  const formulario = new formPerguntas()
   const labels = Cypress.env('labels')
   const { msgSucesso } = labels.perguntas
 
@@ -1139,7 +1110,7 @@ Cypress.Commands.add('salvarPergunta', (descPergunta, index) => {
   cy.get(`tr[id='question-new-${index}']`)
     .parent('tbody')
     .within(() => {
-      formulario.salvar()
+      formPerguntas.salvar()
     })  
 
   // Confirma a mensagem de sucesso
@@ -1152,13 +1123,10 @@ Cypress.Commands.add('salvarPergunta', (descPergunta, index) => {
 })
 
 Cypress.Commands.add('excluirPergunta', (descPergunta) => {
-  const formulario = new formPerguntas()
-
   cy.get(`tr[title*='${descPergunta.slice(0, 30)}']`)
     .parent('tbody')
     .within(() => {
-      formulario.remover()
-    
+      formPerguntas    
       // Lida com a mensagem de confirmação do navegador
       cy.on('window:confirm', (message) => {
         expect(message).to.equal('Você tem certeza que deseja remover esta pergunta?')
@@ -1172,17 +1140,14 @@ Cypress.Commands.add('excluirPergunta', (descPergunta) => {
 })
 
 Cypress.Commands.add('expandirPergunta', (descPergunta) => {
-  const formulario = new formPerguntas()
-
   cy.get(`tr[title*='${descPergunta.slice(0, 30)}']`)
     .parent('tbody')
     .within(() => {
-      formulario.expandirPergunta()
+      formPerguntas.expandirPergunta()
     })  
 })
 
 Cypress.Commands.add('salvarEdicaoPergunta', (oldDescPergunta, newDescPergunta) => {
-  const formulario = new formPerguntas()
   const labels = Cypress.env('labels')
   const { msgSucesso } = labels.perguntas
 
@@ -1190,7 +1155,7 @@ Cypress.Commands.add('salvarEdicaoPergunta', (oldDescPergunta, newDescPergunta) 
   cy.get(`tr[title*='${oldDescPergunta.slice(0, 30)}']`)
     .parent('tbody')
     .within(() => {
-      formulario.salvar()
+      formPerguntas.salvar()
     })  
 
   // Confirma a mensagem de sucesso
@@ -1202,31 +1167,26 @@ Cypress.Commands.add('salvarEdicaoPergunta', (oldDescPergunta, newDescPergunta) 
     .should('be.visible')
 })
 
-Cypress.Commands.add('preencherDadosUsuario', (dados, opcoes = { limpar: false }) => {
-  const formulario = new formUsuarios()
-  
+Cypress.Commands.add('preencherDadosUsuario', (dados, opcoes = { limpar: false }) => { 
   Object.keys(dados).forEach(nomeCampo => {
       const valor = dados[nomeCampo]
-      formulario.preencherCampo(nomeCampo, valor, opcoes)
+      formUsuarios.preencherCampo(nomeCampo, valor, opcoes)
   })
 }) 
 
 Cypress.Commands.add('validarDadosUsuario', (dados) => {
-  const formulario = new formUsuarios()
-
   Object.keys(dados).forEach(nomeCampo => {
     const valor = dados[nomeCampo] !== undefined ? dados[nomeCampo] : valorDefault
-    formulario.validarCampo(nomeCampo, valor)
+    formUsuarios.validarCampo(nomeCampo, valor)
   })
 })
 
 Cypress.Commands.add('salvarUsuario', (nomeUsuario) => {
-  const formulario = new formUsuarios()
   const labels = Cypress.env('labels')
   const { msgSucesso } = labels.usuarios
 
   // Salva o usuário
-  formulario.salvar()
+  formUsuarios.salvar()
 
   // Confirma a mensagem de sucesso
   cy.contains('.flash.success', msgSucesso)
@@ -1582,30 +1542,25 @@ Cypress.Commands.add('addParticipanteConteudo', function(nomeConteudo, tipoConte
 })
 
 Cypress.Commands.add('preencherDadosParticipante', (conteudo, opcoes = { limpar: false }) => {
-  const formulario = new formParticipantes()
-  
   Object.keys(conteudo).forEach(nomeCampo => {
       const valor = conteudo[nomeCampo]
-      formulario.preencherCampo(nomeCampo, valor, opcoes)
+      formParticipantes.preencherCampo(nomeCampo, valor, opcoes)
   })
 }) 
 
 Cypress.Commands.add('validarDadosParticipante', (conteudo) => {
-  const formulario = new formParticipantes()
-
   Object.keys(conteudo).forEach(nomeCampo => {
     const valor = conteudo[nomeCampo] !== undefined ? conteudo[nomeCampo] : valorDefault
-    formulario.validarCampo(nomeCampo, valor)
+    formParticipantes.validarCampo(nomeCampo, valor)
   })
 })
 
 Cypress.Commands.add('salvarNovoParticipante', (nomeParticipante) => {
-  const formulario = new formParticipantes()
   const labels = Cypress.env('labels')
   const { msgSucesso } = labels.participantes
 
   // Salva o usuário
-  formulario.salvar()
+  formParticipantes.salvar()
 
   // Confirma a mensagem de sucesso
   cy.contains('.flash.notice', msgSucesso)
@@ -1617,12 +1572,11 @@ Cypress.Commands.add('salvarNovoParticipante', (nomeParticipante) => {
 })
 
 Cypress.Commands.add('salvarEdicaoParticipante', (nomeParticipante, status = 'Confirmados') => {
-  const formulario = new formParticipantes()
   const labels = Cypress.env('labels')
   const { msgSucessoEdicao } = labels.participantes
 
   // Salva o usuário
-  formulario.salvar()
+  formParticipantes.salvar()
 
   // Confirma a mensagem de sucesso
   cy.contains('.flash.notice', msgSucessoEdicao)
@@ -2152,30 +2106,23 @@ Cypress.Commands.add('configUsuario', (idioma = 'pt') => {
 })
 
 Cypress.Commands.add('preencherDadosConfigUsuario', (dados, opcoes = { limpar: false }) => {
-  const formulario = new formConfigUsuario()
-  
   Object.keys(dados).forEach(nomeCampo => {
       const valor = dados[nomeCampo]
-      formulario.preencherCampo(nomeCampo, valor, opcoes)
+      formConfigUsuario.preencherCampo(nomeCampo, valor, opcoes)
   })
 })
 
 Cypress.Commands.add('vincularInstrutor', (nomeInstrutor) => {
-  const formulario = new formInstrutor()
-
-  formulario.associarInstrutor(nomeInstrutor)
-
+  formInstrutor.associarInstrutor(nomeInstrutor)
 })
 
 Cypress.Commands.add('vinculoGestao', (nomeGestor, acao) => {
-  const formulario = new formGestor()
-
   switch(acao) {
     case 'Vincular':
-      formulario.vincularGestor(nomeGestor)
+      formGestor.vincularGestor(nomeGestor)
       break
     case  'Desvincular':
-      formulario.desvincularGestor(nomeGestor)
+      formGestor.desvincularGestor(nomeGestor)
       break
   }
 })
@@ -2245,11 +2192,9 @@ Cypress.Commands.add('criarInstrutor', (nomeInstrutor, sobrenomeInstrutor) => {
 })
 
 Cypress.Commands.add('validarDadosConfigUsuario', (dados) => {
-  const formulario = new formConfigUsuario()
-
   Object.keys(dados).forEach(nomeCampo => {
     const valor = dados[nomeCampo] !== undefined ? dados[nomeCampo] : valorDefault
-    formulario.validarCampo(nomeCampo, valor)
+    formConfigUsuario.validarCampo(nomeCampo, valor)
   })
 })
 
@@ -2524,22 +2469,21 @@ Cypress.Commands.add('ativarCapturaErros', function() {
 })
 
 Cypress.Commands.add('criarAmbienteAdicional', (acao, dadosAmbiente, opcoes = { limpar: true }) => {
-  const formulario = new formAmbientesAdicionais()
   const labels = Cypress.env('labels')
   const { msgSucesso } = labels.ambientesAdicionais
   
   if (acao === 'Criar') {
-    formulario.criarAmbienteAdicional()
+    formAmbientesAdicionais.criarAmbienteAdicional()
   } else if (acao === 'Adicionar') {
-    formulario.adicionarAmbienteAdicional()
+    formAmbientesAdicionais.adicionarAmbienteAdicional()
   }
   
   Object.keys(dadosAmbiente).forEach(nomeCampo => {
       const valor = dadosAmbiente[nomeCampo]
-      formulario.preencherCampo(nomeCampo, valor, opcoes)
+      formAmbientesAdicionais.preencherCampo(nomeCampo, valor, opcoes)
   })
 
-  formulario.salvarAmbiente()
+  formAmbientesAdicionais.salvarAmbiente()
   cy.contains('#success-toast', msgSucesso)
         .should('be.visible')
 }) 
@@ -2561,17 +2505,16 @@ Cypress.Commands.add('validarAmbienteAdicional', (dadosAmbiente, acao) => {
 })
 
 Cypress.Commands.add('inativarAmbienteAdicional', (nomeAmbiente) => {
-  const formulario = new formAmbientesAdicionais()
   const labels = Cypress.env('labels')
   const { msgInativacao } = labels.ambientesAdicionais
 
   cy.contains('div', nomeAmbiente).within(() => {
-    cy.get(formulario.elementos.inativar.seletor)
+    cy.get(formAmbientesAdicionais.elementos.inativar.seletor)
     .click()
   })   
 
   // Confirmar a inativação do ambiente
-  formulario.confirmarInativacaoAmbiente()
+  formAmbientesAdicionais.confirmarInativacaoAmbiente()
   
   // Valida a mensagem de sucesso
   cy.contains('.chakra-alert__desc.css-zycdy9', msgInativacao)
@@ -2619,11 +2562,10 @@ Cypress.Commands.add('compartilharComAmbienteAdicional', (nomeAmbiente, acao) =>
 })
 
 Cypress.Commands.add('salvarCompartilhamentoAmbienteAdicional', () => {
-  const formulario = new formConteudosAmbienteAdicional()
   const labels = Cypress.env('labels')
   const { msgCompartilhamento } = labels.ambientesAdicionais
 
-  formulario.salvarCompartilhamento()
+  formConteudosAmbienteAdicional.salvarCompartilhamento()
 
   // Valida a mensagem de sucesso
   cy.contains('.chakra-alert__desc', msgCompartilhamento)
@@ -2672,27 +2614,25 @@ Cypress.Commands.add('inativarTodosAmbientesAdicionais', () => {
 })
 
 Cypress.Commands.add('preencherDadosConfigOrganizacao', (dados, aba, opcoes = { limpar: false }) => {
-  const formulario = new formConfigOrganizacao()
-
   if (aba) {
     switch (aba) {
       case 'dados':
-        formulario.abaDados()
+        formConfigOrganizacao.abaDados()
         break
       case 'customizacoes':
-        formulario.abaCustomizacoes()
+        formConfigOrganizacao.abaCustomizacoes()
         break
       case 'certificado':
-        formulario.abaCertificado()
+        formConfigOrganizacao.abaCertificado()
         break
       case 'integracoes':
-        formulario.abaIntegracoes()
+        formConfigOrganizacao.abaIntegracoes()
         break
       case 'termos':
-        formulario.abaTermos()
+        formConfigOrganizacao.abaTermos()
         break
       case 'urlWebhooks':
-        formulario.abaUrlWebhooks()
+        formConfigOrganizacao.abaUrlWebhooks()
         break
       default:
         throw new Error(`Aba inválida: ${aba}. Utilize 'dados', 'customizacoes', 'certificado', 'integracoes', 'termos' ou 'urlWebhooks'`)
@@ -2701,31 +2641,29 @@ Cypress.Commands.add('preencherDadosConfigOrganizacao', (dados, aba, opcoes = { 
   
   Object.keys(dados).forEach(nomeCampo => {
       const valor = dados[nomeCampo]
-      formulario.preencherCampo(nomeCampo, valor, opcoes)
+      formConfigOrganizacao.preencherCampo(nomeCampo, valor, opcoes)
   })
 }) 
 
 Cypress.Commands.add('validarDadosConfigOrganizacao', (dados, aba) => {
-  const formulario = new formConfigOrganizacao()
-
   switch (aba) {
     case 'dados':
-      formulario.abaDados()
+      formConfigOrganizacao.abaDados()
       break
     case 'customizacoes':
-      formulario.abaCustomizacoes()
+      formConfigOrganizacao.abaCustomizacoes()
       break
     case 'certificado':
-      formulario.abaCertificado()
+      formConfigOrganizacao.abaCertificado()
       break
     case 'integracoes':
-      formulario.abaIntegracoes()
+      formConfigOrganizacao.abaIntegracoes()
       break
     case 'termos':
-      formulario.abaTermos()
+      formConfigOrganizacao.abaTermos()
       break
     case 'urlWebhooks':
-      formulario.abaUrlWebhooks()
+      formConfigOrganizacao.abaUrlWebhooks()
       break
     default:
       throw new Error(`Aba inválida: ${aba}. Utilize 'dados', 'customizacoes', 'certificado', 'integracoes', 'termos' ou 'urlWebhooks'`)
@@ -2733,7 +2671,7 @@ Cypress.Commands.add('validarDadosConfigOrganizacao', (dados, aba) => {
 
   Object.keys(dados).forEach(nomeCampo => {
     const valor = dados[nomeCampo] !== undefined ? dados[nomeCampo] : valorDefault
-    formulario.validarCampo(nomeCampo, valor)
+    formConfigOrganizacao.validarCampo(nomeCampo, valor)
   })
 })
 
@@ -3046,20 +2984,16 @@ Cypress.Commands.add('editarUrlWebhook', (nomeFuncao, url) => {
 })
 
 Cypress.Commands.add('preencherDadosTrial', (dados, opcoes = { limpar: false }) => {
-  const formulario = new formTrial()
-
   Object.keys(dados).forEach(nomeCampo => {
     const valor = dados[nomeCampo]
-    formulario.preencherCampo(nomeCampo, valor, opcoes)
+    formTrial.preencherCampo(nomeCampo, valor, opcoes)
   })
 })
 
 Cypress.Commands.add('validarDadosTrial', (dados) => {
-  const formulario = new formTrial()
-  
   Object.keys(dados).forEach(nomeCampo => {
     const valor = dados[nomeCampo] !== undefined ? dados[nomeCampo] : valorDefault
-    formulario.validarCampo(nomeCampo, valor)
+    formTrial.validarCampo(nomeCampo, valor)
   })
 })
 
@@ -3265,29 +3199,24 @@ Cypress.Commands.add('validarMsgTrial', (step, objetivo, nomeUsuario) => {
 })
 
 Cypress.Commands.add('preencherDadosCobrancaAutomatica', (conteudo, opcoes = { limpar: false }) => {
-  const formulario = new formCobrancaAutomatica()
-  
   Object.keys(conteudo).forEach(nomeCampo => {
       const valor = conteudo[nomeCampo]
-      formulario.preencherCampo(nomeCampo, valor, opcoes)
+      formCobrancaAutomatica.preencherCampo(nomeCampo, valor, opcoes)
   })
 }) 
 
 Cypress.Commands.add('validarDadosCobrancaAutomatica', (conteudo) => {
-  const formulario = new formCobrancaAutomatica()
-
   Object.keys(conteudo).forEach(nomeCampo => {
     const valor = conteudo[nomeCampo] !== undefined ? conteudo[nomeCampo] : valorDefault
-    formulario.validarCampo(nomeCampo, valor)
+    formCobrancaAutomatica.validarCampo(nomeCampo, valor)
   })
 })
 
 Cypress.Commands.add('salvarCobrancaAutomatica', () => {
-  const formulario = new formCobrancaAutomatica()
   const labels = Cypress.env('labels')
   const { msgSucesso } = labels.cobrancaInscricao.cobrancaAutomatica
 
-  formulario.salvar()
+  formCobrancaAutomatica.salvar()
   validarModalSubstCobranca()
   
   // Valida a mensagem de sucesso
@@ -3296,8 +3225,6 @@ Cypress.Commands.add('salvarCobrancaAutomatica', () => {
 })
 
 Cypress.Commands.add('resetCobrancaAutomatica', () => {
-  const formulario = new formCobrancaAutomatica()
-
   const dados = {
     radioAsaas: true,
     chaveAsaas: 'a',
@@ -3315,7 +3242,7 @@ Cypress.Commands.add('resetCobrancaAutomatica', () => {
   // Desabilitar o "Pix e boleto"
   cy.preencherDadosCobrancaAutomatica({ checkPixBoleto: false})
 
-  formulario.salvar()
+  formCobrancaAutomatica.salvar()
   validarModalSubstCobranca()
 
   // Desabilitar a cobrança automática

--- a/cypress/support/pageObjects/estruturaAtividades.js
+++ b/cypress/support/pageObjects/estruturaAtividades.js
@@ -17,4 +17,4 @@ class estruturaAtividades {
         this.elementos.btnCopiarAtividade().click()
     }
 }
-export default estruturaAtividades
+export default new estruturaAtividades

--- a/cypress/support/pageObjects/formAmbientesAdicionais.js
+++ b/cypress/support/pageObjects/formAmbientesAdicionais.js
@@ -125,4 +125,4 @@ class formAmbientesAdicionais {
             .click()
     }
 }
-export default formAmbientesAdicionais
+export default new formAmbientesAdicionais

--- a/cypress/support/pageObjects/formAtividades.js
+++ b/cypress/support/pageObjects/formAtividades.js
@@ -440,4 +440,4 @@ class formAtividades {
 			.click()
 	}
 }
-export default formAtividades
+export default new formAtividades

--- a/cypress/support/pageObjects/formBiblioteca.js
+++ b/cypress/support/pageObjects/formBiblioteca.js
@@ -113,4 +113,4 @@ class formBiblioteca {
             .click()
     }
 }
-export default formBiblioteca
+export default new formBiblioteca

--- a/cypress/support/pageObjects/formCobrancaAutomatica.js
+++ b/cypress/support/pageObjects/formCobrancaAutomatica.js
@@ -207,4 +207,4 @@ class formCobrancaAutomatica {
 			}
 	}
 }
-export default formCobrancaAutomatica
+export default new formCobrancaAutomatica

--- a/cypress/support/pageObjects/formConfigOrganizacao.js
+++ b/cypress/support/pageObjects/formConfigOrganizacao.js
@@ -537,4 +537,4 @@ class formConfigOrganizacao {
 			}
 	}
 }
-export default formConfigOrganizacao
+export default new formConfigOrganizacao

--- a/cypress/support/pageObjects/formConfigUsuario.js
+++ b/cypress/support/pageObjects/formConfigUsuario.js
@@ -195,4 +195,4 @@ class formConfigUsuario {
         }
     }
 }
-export default formConfigUsuario
+export default new formConfigUsuario

--- a/cypress/support/pageObjects/formConteudos.js
+++ b/cypress/support/pageObjects/formConteudos.js
@@ -415,4 +415,4 @@ class formConteudos {
 			.click()
 	}
 }
-export default formConteudos
+export default new formConteudos

--- a/cypress/support/pageObjects/formConteudosAmbienteAdicional.js
+++ b/cypress/support/pageObjects/formConteudosAmbienteAdicional.js
@@ -20,4 +20,4 @@ class formConteudosAmbienteAdicional {
             .click()
     }
 }
-export default formConteudosAmbienteAdicional
+export default new formConteudosAmbienteAdicional

--- a/cypress/support/pageObjects/formGestor.js
+++ b/cypress/support/pageObjects/formGestor.js
@@ -67,4 +67,4 @@ class formGestor{
             .click()
     }
 }
-export default formGestor
+export default new formGestor

--- a/cypress/support/pageObjects/formInstrutor.js
+++ b/cypress/support/pageObjects/formInstrutor.js
@@ -104,4 +104,4 @@ class formInstrutor{
 		}
 	}
 }
-export default formInstrutor
+export default new formInstrutor

--- a/cypress/support/pageObjects/formParticipantes.js
+++ b/cypress/support/pageObjects/formParticipantes.js
@@ -290,4 +290,4 @@ class formParticipantes {
 		}
 	}
 }
-export default formParticipantes
+export default new formParticipantes

--- a/cypress/support/pageObjects/formPerguntas.js
+++ b/cypress/support/pageObjects/formPerguntas.js
@@ -215,4 +215,4 @@ class formPerguntas {
 		}
 	}
 }
-export default formPerguntas
+export default new formPerguntas

--- a/cypress/support/pageObjects/formQuestionarios.js
+++ b/cypress/support/pageObjects/formQuestionarios.js
@@ -277,4 +277,4 @@ class formQuestionarios {
             .click()
     }
 }
-export default formQuestionarios
+export default new formQuestionarios

--- a/cypress/support/pageObjects/formTrial.js
+++ b/cypress/support/pageObjects/formTrial.js
@@ -263,4 +263,4 @@ class formTrial {
 			}
 	}
 }
-export default formTrial
+export default new formTrial

--- a/cypress/support/pageObjects/formUsuarios.js
+++ b/cypress/support/pageObjects/formUsuarios.js
@@ -335,4 +335,4 @@ class formUsuarios {
 		}
 	}
 }
-export default formUsuarios
+export default new formUsuarios


### PR DESCRIPTION
#### 🤖 FUNCIONALIDADE
Geral

#### 🎯 AUTOMAÇÃO
Removidas as variáveis 'const formulario' que estavam instanciando as page objects e adicionado 'new' na exportação default da própria page.

#### :heavy_check_mark: ATIVIDADE
[Remover 'const formulario', alterar 'formulario' para nome da classe e realizar 'export default new'](https://app.artia.com/a/4874953/f/5152797/activities/27800794)

#### :hammer_and_wrench: Tipo de mudança
 - [ ] Novos cenários (mudança que adiciona novos cenários automatizados)
 - [ ] Correção de quebras (alteração que corrige um problema)
 - [ ] Atualização de cenários (quando alterada a regra de negócio)
 - [X] Refatoração (Mudança no código que mantém o funcionamento como esperado)
 - [ ] Esta mudança requer uma atualização dos casos de testes no TestLink

#### :checkered_flag: CHECKLIST
- [X] Meu código segue as diretrizes de estilo deste projeto
- [X] Eu fiz uma autoavaliação do meu próprio código
- [X] Eu validei meus testes confirmando que minha implementação é eficaz ou que ela funciona como esperado
